### PR TITLE
Improve display of  interpreter errors

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -11,6 +11,7 @@ fmap
 foldl
 foldr
 fst
+ghc
 GHC
 github
 Graphviz

--- a/flex-task/src/FlexTask/Interpreter.hs
+++ b/flex-task/src/FlexTask/Interpreter.hs
@@ -302,7 +302,7 @@ imageLinks = concatMap gatherLinks
 Custom display of Hint InterpreterError messages.
 -}
 prettyError :: InterpreterError -> String
-prettyError (UnknownError s) = "Unknown Error: " ++ s
-prettyError (NotAllowed s) = "Not allowed: " ++ s
-prettyError (GhcException s) = "GHC exception occured: " ++ s
-prettyError (WontCompile ghcErrors) = "Won't compile: " ++ unlines (map errMsg ghcErrors)
+prettyError (UnknownError s) = "Unknown error:\n" ++ s
+prettyError (NotAllowed s) = "Not allowed:\n" ++ s
+prettyError (GhcException s) = "GHC exception occured:\n" ++ s
+prettyError (WontCompile ghcErrors) = "Won't compile:\n" ++ unlines (map errMsg ghcErrors)

--- a/flex-task/src/FlexTask/Interpreter.hs
+++ b/flex-task/src/FlexTask/Interpreter.hs
@@ -304,5 +304,5 @@ Custom display of Hint InterpreterError messages.
 prettyError :: InterpreterError -> String
 prettyError (UnknownError s) = "Unknown error:\n" ++ s
 prettyError (NotAllowed s) = "Not allowed:\n" ++ s
-prettyError (GhcException s) = "GHC exception occured:\n" ++ s
+prettyError (GhcException s) = "GHC exception occurred:\n" ++ s
 prettyError (WontCompile ghcErrors) = "Won't compile:\n" ++ unlines (map errMsg ghcErrors)

--- a/flex-task/src/FlexTask/Interpreter.hs
+++ b/flex-task/src/FlexTask/Interpreter.hs
@@ -10,6 +10,7 @@ The interpreted code is usually supplied by accessing data stored in `FlexInst` 
 module FlexTask.Interpreter
   ( checkSolution
   , genFlexInst
+  , prettyError
   , runWithPackageDB
   , validDescription
   ) where
@@ -182,14 +183,14 @@ checkSolution
   -> String   -- ^ Module containing /checkSyntax/ and /checkSemantics/
   -> String   -- ^ Student solution
   -> FilePath -- ^ Path images will be stored in
-  -> IO ([Output], Maybe (Maybe Rational, [Output]))
+  -> IO (Either InterpreterError ([Output], Maybe (Maybe Rational, [Output])))
 checkSolution taskData globalCode parseCode checkCode submission picPath = do
     filePaths <- writeUncachedAndGetPaths
       [ ("Global", globalCode)
       , ("Parse", parseCode)
       , ("Check", checkCode)
       ]
-    runWithPackageDB (loadModules filePaths >> runCheck) >>= sequence . extract
+    runWithPackageDB (loadModules filePaths >> runCheck) >>= sequence
   where
     runCheck = do
       setImportsQ
@@ -297,6 +298,9 @@ imageLinks = concatMap gatherLinks
     gatherLinks _                = []
 
 
+{- |
+Custom display of Hint InterpreterError messages.
+-}
 prettyError :: InterpreterError -> String
 prettyError (UnknownError s) = "Unknown Error: " ++ s
 prettyError (NotAllowed s) = "Not allowed: " ++ s


### PR DESCRIPTION
Unpack the InterpreterError type and directly print the strings 