### PR TITLE
Simplify and allow for sharing of "delayed style" parsing

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -21,6 +21,7 @@ html
 mform
 MForms
 mopt
+Parserfehler
 pkgdb
 standalone
 typeclasses

--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -21,7 +21,6 @@ html
 mform
 MForms
 mopt
-Parserfehler
 pkgdb
 standalone
 typeclasses

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -290,6 +290,7 @@ It only takes your parser as an argument.
 module Parse (parseSubmission) where
 
 
+import Control.OutputCapable.Blocks     (LangM, LangM')
 import FlexTask.Generic.Parse  (parseInput, useParser)
 import Text.Parsec             (ParseError)
 
@@ -297,7 +298,7 @@ import Global
 
 
 
-parseSubmission :: String -> Either ParseError Solution
+parseSubmission :: OutputCapable m => String -> Either (LangM m) (LangM' m a)
 parseSubmission = useParser parseInput
 
 |]

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -290,7 +290,11 @@ It only takes your parser as an argument.
 module Parse (parseSubmission) where
 
 
-import Control.OutputCapable.Blocks     (LangM, LangM')
+import Control.OutputCapable.Blocks (
+  LangM,
+  LangM',
+  OutputCapable,
+  )
 import FlexTask.Generic.Parse  (parseInput, useParser)
 import Text.Parsec             (ParseError)
 
@@ -298,7 +302,7 @@ import Global
 
 
 
-parseSubmission :: OutputCapable m => String -> Either (LangM m) (LangM' m a)
+parseSubmission :: OutputCapable m => String -> Either (LangM m) (LangM' m Solution)
 parseSubmission = useParser parseInput
 
 |]

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -266,36 +266,40 @@ parseSubmission ::
   -> LangM' (ReportT o m) Solution
 
 where the given String is the submission.
-This function should first apply a parser to the submission,
-then embed the result into 'OutputCapable'
+This function should first apply parsing to the submission,
+then embed the result into 'OutputCapable'.
 The type 'LangM' (ReportT o m) Solution' is a specialization of the more general 'LangM' m Solution'.
 'LangM' m Solution' represents sequential output like 'LangM m' or 'Rated m',
-but provides a value of type solution afterwards.
-The function enables more complex error handling
+but provides a value of type Solution afterwards.
+The function thus enables more complex reporting (e.g., of errors)
 than might be possible by purely using basic parsers alone.
 The final result is passed to the check functions to generate feedback.
 
-To implement parseSubmission you can use the 'useParser' and 'parseWithFallback' functions,
-supplied by 'FlexTask.Generic.Parse'.
-The 'useParser' function takes a parser and the 'String' input as an argument
+The parsers used throughout are those of 'Text.Parsec'.
+Refer to its documentation if necessary.
+
+To implement parseSubmission, you will typically invoke 'useParser' and
+possibly 'parseWithFallback' or 'parseWithMessage', all
+supplied by 'FlexTask.Generic.Parse'. In simple situations, '<&>' may suffice.
+The 'useParser' function takes a parser and the 'String' input as arguments
 and embeds the result directly into 'OutputCapable'.
 This function directly reads the form results.
-Use this if you do not need additional processing of the input.
-The parsers used there are those of 'Text.Parsec'.
-Refer to its documentation if necessary.
-The 'parseWithFallback' function can be used to parse additional Strings from the form result.
+It is enough if you do not need additional processing of the input.
+The 'parseWithFallback' function can be used to additionally parse/process
+Strings from among the form result, that is, individual input fields.
 It should be used after 'useParser', instead of on its own.
-'parseWithFallback' takes a parser, function, fallback parser and the input.
-The secondary parser is used on the input in case of an error.
-The possible error of this parser and the initial error
-are then fed to the function to construct the report.
-Use this to create more sophisticated error messages.
+'parseWithFallback' takes a parser, messaging function, fallback parser and the input.
+The secondary parser is used as a simpler sanity check on the input in case
+of an error with the primary parser.
+The possible error of the fallback parser and the original error
+are then fed to the messaging function to construct the report.
+Use this to produce more sophisticated error messages.
 
-If you want to chain multiple parsing steps, e.g. with 'parseWithFallback'
+If you want to chain multiple parsing steps, e.g. with 'parseWithFallback',
 use '$>>=' of 'Control.OutputCapable.Blocks.Generic'.
 This operation can be seen as a '>>=' equivalent for 'LangM''.
 Example:
-'useParser parseInput input $>>= parseWithFallback p someFunc fallback $>>= ...'
+'useParser parseInput input $>>= \s -> parseWithFallback p someFunc fallback s $>>= pure . ...'
 
 As with forms, a generic parser interface is available.
 The steps are similar:

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -267,17 +267,17 @@ This function should first apply a parser to the submission
 and then optionally process the input further or leave it as is.
 Finally, the result is embedded into 'OutputCapable'.
 The type LangM' is a variation of LangM, allowing for arbitrary embedded content instead of only '()'
-This enables more complex error handling,
-which might not be possible by purely using basic parsers alone.
+The function enables more complex error handling
+than might be possible by purely using basic parsers alone.
 The final result is passed to the check functions to generate feedback.
-The parsers used are those of 'Text.Parsec'.
-Refer to its documentation if necessary.
 
 To implement parseSubmission you can use the 'useParser' and 'useParserAnd' functions,
 supplied by 'FlexTask.Generic.Parse'.
-'useParser' takes a parser as an argument and embeds the result directly into 'OutputCapable'.
+The parsers used there are those of 'Text.Parsec'.
+Refer to its documentation if necessary.
+The 'useParser' function takes a parser as an argument and embeds the result directly into 'OutputCapable'.
 Use this if you do not need additional processing of the input.
-'useParserAnd' takes a parser and a processing function as arguments.
+The 'useParserAnd' function takes a parser and a processing function as arguments.
 This function will first parse the solution, then apply the processing to the output.
 
 As with forms, a generic parser interface is available.

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -291,7 +291,6 @@ module Parse (parseSubmission) where
 
 
 import Control.OutputCapable.Blocks (
-  LangM,
   LangM',
   OutputCapable,
   )
@@ -302,7 +301,7 @@ import Global
 
 
 
-parseSubmission :: OutputCapable m => String -> Either (LangM m) (LangM' m Solution)
+parseSubmission :: OutputCapable m => String -> LangM' m Solution
 parseSubmission = useParser parseInput
 
 |]

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -260,25 +260,36 @@ dParse = [rQ|
 Module for parsing the student submission.
 Must contain the function
 
-parseSubmission :: OutputCapable m => String -> LangM' m Solution
+parseSubmission ::
+  (Monad m, OutputCapable (ReportT o m))
+  => String
+  -> LangM' (ReportT o m) Solution
 
 where the given String is the submission.
-This function should first apply a parser to the submission
-and then optionally process the input further or leave it as is.
-Finally, the result is embedded into 'OutputCapable'.
-The type LangM' is a variation of LangM, allowing for arbitrary embedded content instead of only '()'
+This function should first apply a parser to the submission,
+then embed the result into 'OutputCapable'
+The type 'LangM' (ReportT o m) Solution' is a specialization of the more general 'LangM' m Solution'.
+'LangM' m Solution' represents sequential output like 'LangM m' or 'Rated m',
+but provides a value of type solution afterwards.
 The function enables more complex error handling
 than might be possible by purely using basic parsers alone.
 The final result is passed to the check functions to generate feedback.
 
-To implement parseSubmission you can use the 'useParser' and 'useParserAnd' functions,
+To implement parseSubmission you can use the 'useParser' or 'parseWithOrReport' functions,
 supplied by 'FlexTask.Generic.Parse'.
+The 'useParser' function takes a parser and the 'String' input as an argument
+and embeds the result directly into 'OutputCapable'.
+Use this if you do not need additional processing of the input.
 The parsers used there are those of 'Text.Parsec'.
 Refer to its documentation if necessary.
-The 'useParser' function takes a parser as an argument and embeds the result directly into 'OutputCapable'.
-Use this if you do not need additional processing of the input.
-The 'useParserAnd' function takes a parser and a processing function as arguments.
-This function will first parse the solution, then apply the processing to the output.
+The 'parseWithOrReport' function is a more general version of 'useParser'.
+It takes a function to parse the input, a function to edit the parse error and the input itself.
+The arguments of this function are not limited to 'String', 'Parsec' parsers and ParseErrors.
+Use this to incorporate complex external parsers or create more sophisticated error messages.
+
+If you want to chain multiple parsing steps,
+use '$>>=' (infix) of 'Control.OutputCapable.Blocks.Generic'.
+This operation can be seen as a '>>=' equivalent for 'LangM''.
 
 As with forms, a generic parser interface is available.
 The steps are similar:

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -260,11 +260,24 @@ dParse = [rQ|
 Module for parsing the student submission.
 Must contain the function
 
-parseSubmission :: String -> Either ParseError Solution
+parseSubmission :: OutputCapable m => String -> LangM' m Solution
 
 where the given String is the submission.
+This function should first apply a parser to the submission
+and then optionally process the input further or leave it as is.
+Finally, the result is embedded into 'OutputCapable'.
+The type LangM' is a variation of LangM, allowing for arbitrary embedded content instead of only '()'
+This enables more complex error handling,
+which might not be possible by purely using basic parsers alone.
+The final result is passed to the check functions to generate feedback.
 The parsers used are those of 'Text.Parsec'.
 Refer to its documentation if necessary.
+
+To implement parseSubmission, you can use the 'useParser' and 'useParserAnd' functions, supplied by 'FlexTask.Generic.Parse'.
+'useParser' takes a parser as an argument and embeds the result directly into 'OutputCapable'.
+Use this if you do not need additional processing of the input.
+'useParserAnd' takes a parser and a processing function as arguments.
+This function will first parse the solution, then apply the processing to the output.
 
 As with forms, a generic parser interface is available.
 The steps are similar:
@@ -281,9 +294,6 @@ Instead, use bodyless instances for the component types where possible
 and use custom parsers for those where not applicable.
 Finally, use the bodyless instance method for the entire type.
 This is again necessary to avoid encoding problems that are caused internally by argument delimiters.
-
-To implement parseSubmission, you can use the 'useParser' function, again supplied by 'FlexTask.Generic.Parse'.
-It only takes your parser as an argument.
 !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
 -}
 

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -295,7 +295,6 @@ import Control.OutputCapable.Blocks (
   OutputCapable,
   )
 import FlexTask.Generic.Parse  (parseInput, useParser)
-import Text.Parsec             (ParseError)
 
 import Global
 

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -303,6 +303,7 @@ module Parse (parseSubmission) where
 
 import Control.OutputCapable.Blocks (
   LangM',
+  ReportT,
   OutputCapable,
   )
 import FlexTask.Generic.Parse  (parseInput, useParser)
@@ -311,7 +312,10 @@ import Global
 
 
 
-parseSubmission :: OutputCapable m => String -> LangM' m Solution
+parseSubmission ::
+  (Monad m, OutputCapable (ReportT o m))
+  => String
+  -> LangM' (ReportT o m) Solution
 parseSubmission = useParser parseInput
 
 |]

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -273,7 +273,8 @@ The final result is passed to the check functions to generate feedback.
 The parsers used are those of 'Text.Parsec'.
 Refer to its documentation if necessary.
 
-To implement parseSubmission, you can use the 'useParser' and 'useParserAnd' functions, supplied by 'FlexTask.Generic.Parse'.
+To implement parseSubmission you can use the 'useParser' and 'useParserAnd' functions,
+supplied by 'FlexTask.Generic.Parse'.
 'useParser' takes a parser as an argument and embeds the result directly into 'OutputCapable'.
 Use this if you do not need additional processing of the input.
 'useParserAnd' takes a parser and a processing function as arguments.

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -282,10 +282,12 @@ and embeds the result directly into 'OutputCapable'.
 Use this if you do not need additional processing of the input.
 The parsers used there are those of 'Text.Parsec'.
 Refer to its documentation if necessary.
-The 'parseWithOrReport' function is a more general version of 'useParser'.
-It takes a function to parse the input, a function to edit the parse error and the input itself.
-The arguments of this function are not limited to 'String', 'Parsec' parsers and ParseErrors.
-Use this to incorporate complex external parsers or create more sophisticated error messages.
+The 'useParserWithFallback' function is a more involved version of 'useParser'.
+It additionally takes a fallback parser and a function.
+The secondary parser is used on the input in case of an error.
+The possible error of this parser and the initial error
+are then fed to the function to construct the report.
+Use this to create more sophisticated error messages.
 
 If you want to chain multiple parsing steps,
 use '$>>=' (infix) of 'Control.OutputCapable.Blocks.Generic'.

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -275,23 +275,27 @@ The function enables more complex error handling
 than might be possible by purely using basic parsers alone.
 The final result is passed to the check functions to generate feedback.
 
-To implement parseSubmission you can use the 'useParser' or 'parseWithOrReport' functions,
+To implement parseSubmission you can use the 'useParser' and 'parseWithFallback' functions,
 supplied by 'FlexTask.Generic.Parse'.
 The 'useParser' function takes a parser and the 'String' input as an argument
 and embeds the result directly into 'OutputCapable'.
+This function directly reads the form results.
 Use this if you do not need additional processing of the input.
 The parsers used there are those of 'Text.Parsec'.
 Refer to its documentation if necessary.
-The 'useParserWithFallback' function is a more involved version of 'useParser'.
-It additionally takes a fallback parser and a function.
+The 'parseWithFallback' function can be used to parse additional Strings from the form result.
+It should be used after 'useParser', instead of on its own.
+'parseWithFallback' takes a parser, function, fallback parser and the input.
 The secondary parser is used on the input in case of an error.
 The possible error of this parser and the initial error
 are then fed to the function to construct the report.
 Use this to create more sophisticated error messages.
 
-If you want to chain multiple parsing steps,
-use '$>>=' (infix) of 'Control.OutputCapable.Blocks.Generic'.
+If you want to chain multiple parsing steps, e.g. with 'parseWithFallback'
+use '$>>=' of 'Control.OutputCapable.Blocks.Generic'.
 This operation can be seen as a '>>=' equivalent for 'LangM''.
+Example:
+'useParser parseInput input $>>= parseWithFallback p someFunc fallback $>>= ...'
 
 As with forms, a generic parser interface is available.
 The steps are similar:

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -247,6 +247,7 @@ parseText t = string $ T.unpack t
 {- |
 Parses a String with the given parser and embeds the result into the `OutputCapable` interface.
 Reports a `ParseError` via `reject` primitive instead.
+Error Reports also provide positional information of the error in the input form.
 -}
 useParser :: OutputCapable m => Parser a -> String -> LangM' m a
 useParser p = useParserAnd p pure
@@ -254,9 +255,8 @@ useParser p = useParserAnd p pure
 
 
 {- |
-Parses a String with the given parser, then applies a processing function to the result.
-The function should embed its final result into the `OutputCapable` interface.
-Reports a `ParseError` via `reject` primitive instead.
+Like `useParser` but also applies a processing function to the parse result.
+The function should embed its final output into the `OutputCapable` interface.
 -}
 useParserAnd :: OutputCapable m => Parser a -> (a -> LangM' m b) -> String -> LangM' m b
 useParserAnd p f input = case parse p "" input of

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -255,9 +255,9 @@ parseText t = string $ T.unpack t
 
 
 {- |
-Parses a String with the given parser and embeds the result into the `OutputCapable` interface.
+Parses a String with the given input form parser and embeds the result into the `OutputCapable` interface.
 No value will be embedded in case of a `ParseError`.
-Instead, an error report is given via `refuse` primitive instead.
+Instead, an error report is given then.
 Error reports provide positional information of the error in the input form.
 -}
 useParser

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -304,13 +304,16 @@ parseWithFallback ::
   -- ^ The input
   -> LangM' (ReportT o m) a
   -- ^ The finished error report or embedded value
-parseWithFallback parser messaging fallBackParser answer =
+parseWithFallback parser messaging fallBackParser =
   processWithOrReport
-    (parse (fully parser) answer)
-    (\a -> messaging $ either Just (const Nothing) (parse (fully fallBackParser) a a))
-    answer
+    (parse (fully parser) "")
+    (\a err -> displayInput a >>
+      messaging (either Just (const Nothing) (parse (fully fallBackParser) "" a)) err)
   where
     fully p = spaces *> p <* eof
+    displayInput a = do
+      german $ "Fehler in \"" ++ a ++ "\": "
+      english $ "Error in \"" ++ a ++ "\": "
 
 
 {- |

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -20,6 +20,9 @@ import Control.OutputCapable.Blocks (
   refuse,
   code,
   )
+import Control.OutputCapable.Blocks.Generic (
+  ($>>=),
+  )
 import Data.Bifunctor     (bimap)
 import Data.Text          (Text)
 import GHC.Generics       (Generic(..), K1(..), M1(..), (:*:)(..))
@@ -246,6 +249,11 @@ parseText t = string $ T.unpack t
 
 useParser :: OutputCapable m => Parser a -> String -> Either (LangM m) (LangM' m a)
 useParser p input = bimap (refuse . code . showWithFieldNumber input) pure (parse p "" input)
+
+
+
+useParserAnd :: (Monad m, OutputCapable m, Parse a) => Parser a -> (a -> LangM' m b) -> String -> Either (LangM m) (LangM' m b)
+useParserAnd p f = fmap ($>>= f) . useParser p
 
 
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -9,7 +9,7 @@ module FlexTask.Generic.ParseInternal
   , parseInstanceMultiChoice
   , escaped
   , useParser
-  , useParserWithFallback
+  , parseWithFallback
   ) where
 
 
@@ -281,14 +281,14 @@ processWithOrReport initialParse errorMsg answer =
 
 
 {- |
-A more complex version of `useParser`.
+Parses a String with the given parser.
 Allows for further processing of a possible parse error.
 A second parser is used as a fallback in case of an error.
 The result of both parsers is then used to construct the report.
 This can be useful for giving better error messages,
 e.g. checking a term for bracket consistency even if the parser failed early on.
 -}
-useParserWithFallback ::
+parseWithFallback ::
   (Monad m, OutputCapable (ReportT o m))
   => Parser a
   -- ^ Parser to use initially
@@ -303,7 +303,7 @@ useParserWithFallback ::
   -- ^ The input
   -> LangM' (ReportT o m) a
   -- ^ The finished error report or embedded value
-useParserWithFallback parser messaging fallBackParser =
+parseWithFallback parser messaging fallBackParser =
   processWithOrReport
     (parse (fully parser) "")
     (messaging . either Just (const Nothing) . parse (fully fallBackParser) "(answer string)")

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -248,7 +248,7 @@ parseText t = string $ T.unpack t
 Parses a String with the given parser and embeds the result into the `OutputCapable` interface.
 Reports a `ParseError` via `refuse` primitive instead.
 Error Reports provide positional information of the error in the input form.
-The embedded value will be undefined in case of a `ParseError`.
+No defined value will be embedded in case of a `ParseError`.
 -}
 useParser
   :: (Monad m, OutputCapable m)
@@ -262,8 +262,8 @@ useParser p = useParserAnd p pure
 {- |
 Like `useParser` but also applies a processing function to the parse result, if it succeeds.
 The function should embed its final output into the `OutputCapable` interface.
-The embedded value will be undefined in case of a `ParseError`.
-The provided function will not be applied to the value in this case.
+No defined value will be embedded in case of a `ParseError`.
+Also, the provided function will not be applied in this case.
 -}
 useParserAnd
   :: (Monad m, OutputCapable m)

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -276,9 +276,9 @@ e.g. checking a term for bracket consistency even if the parser failed early on.
 -}
 parseWithOrReport ::
   (Monad m, OutputCapable (ReportT o m))
-  => (a -> Either ParseError b)
+  => (a -> Either err b)
   -- ^ How to parse the input initially
-  -> (a -> ParseError -> State (Map Language String) ())
+  -> (a -> err -> State (Map Language String) ())
   -- ^ How to create the error report given the input and initial parse error
   -> a
   -- ^ The input
@@ -286,8 +286,8 @@ parseWithOrReport ::
   -- ^ The parse result embedded in `OutputCapable` or the error report
 parseWithOrReport initialParse errorMsg answer =
   case initialParse answer of
-    Left err       -> toAbort $ indent $ translate $ errorMsg answer err
-    Right success  -> pure success
+    Left failure  -> toAbort $ indent $ translate $ errorMsg answer failure
+    Right success -> pure success
 
 
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -271,10 +271,10 @@ useParser p = parseWithOrReport p showWithFieldNumber
 
 parseWithOrReport ::
   (Monad m, OutputCapable (ReportT o m))
-  => Parser b
+  => Parser a
   -> (String -> ParseError -> State (Map Language String) ())
   -> String
-  -> LangM' (ReportT o m) b
+  -> LangM' (ReportT o m) a
 parseWithOrReport parser errorMsg answer =
   case parse parser "" answer of
     Left failure  -> toAbort $ indent $ translate $ errorMsg answer failure

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -244,11 +244,20 @@ parseText t = string $ T.unpack t
 
 
 
+{- |
+Parses a String with the given parser and embeds the result into the `OutputCapable` interface.
+Reports a `ParseError` via `reject` primitive instead.
+-}
 useParser :: OutputCapable m => Parser a -> String -> LangM' m a
 useParser p = useParserAnd p pure
 
 
 
+{- |
+Parses a String with the given parser, then applies a processing function to the result.
+The function should embed its final result into the `OutputCapable` interface.
+Reports a `ParseError` via `reject` primitive instead.
+-}
 useParserAnd :: OutputCapable m => Parser a -> (a -> LangM' m b) -> String -> LangM' m b
 useParserAnd p f input = case parse p "" input of
   Left err -> refuse (code $ showWithFieldNumber input err) $> undefined

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -249,12 +249,12 @@ parseText t = string $ T.unpack t
 
 
 useParser :: OutputCapable m => Parser a -> String -> Either (LangM m) (LangM' m a)
-useParser p input = bimap (refuse . code . showWithFieldNumber input) pure (parse p "" input)
+useParser p = useParserAnd p pure
 
 
 
-useParserAnd :: (Monad m, OutputCapable m) => Parser a -> (a -> LangM' m b) -> String -> Either (LangM m) (LangM' m b)
-useParserAnd p f = fmap ($>>= f) . useParser p
+useParserAnd :: OutputCapable m => Parser a -> (a -> LangM' m b) -> String -> Either (LangM m) (LangM' m b)
+useParserAnd p f input = bimap (refuse . code . showWithFieldNumber input) f (parse p "" input)
 
 
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -304,10 +304,11 @@ parseWithFallback ::
   -- ^ The input
   -> LangM' (ReportT o m) a
   -- ^ The finished error report or embedded value
-parseWithFallback parser messaging fallBackParser =
+parseWithFallback parser messaging fallBackParser answer =
   processWithOrReport
-    (parse (fully parser) "")
+    (parse (fully parser) answer)
     (\a -> messaging $ either Just (const Nothing) (parse (fully fallBackParser) a a))
+    answer
   where
     fully p = spaces *> p <* eof
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -21,9 +21,6 @@ import Control.OutputCapable.Blocks (
   refuse,
   code,
   )
-import Control.OutputCapable.Blocks.Generic (
-  ($>>=),
-  )
 import Data.Bifunctor     (bimap)
 import Data.Text          (Text)
 import GHC.Generics       (Generic(..), K1(..), M1(..), (:*:)(..))

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -9,6 +9,7 @@ module FlexTask.Generic.ParseInternal
   , parseInstanceMultiChoice
   , escaped
   , useParser
+  , useParserAnd
   ) where
 
 
@@ -252,7 +253,7 @@ useParser p input = bimap (refuse . code . showWithFieldNumber input) pure (pars
 
 
 
-useParserAnd :: (Monad m, OutputCapable m, Parse a) => Parser a -> (a -> LangM' m b) -> String -> Either (LangM m) (LangM' m b)
+useParserAnd :: (Monad m, OutputCapable m) => Parser a -> (a -> LangM' m b) -> String -> Either (LangM m) (LangM' m b)
 useParserAnd p f = fmap ($>>= f) . useParser p
 
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -312,8 +312,8 @@ parseWithFallback parser messaging fallBackParser =
   where
     fully p = spaces *> p <* eof
     displayInput a = do
-      german $ "Fehler in \"" ++ a ++ "\": "
-      english $ "Error in \"" ++ a ++ "\": "
+      german $ "Fehler in \"" ++ a ++ "\" : "
+      english $ "Error in \"" ++ a ++ "\" : "
 
 
 {- |

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -17,11 +17,10 @@ import Control.Monad      (void)
 import Control.OutputCapable.Blocks (
   LangM',
   OutputCapable,
-  ReportT,
   refuse,
   code,
   )
-import Control.OutputCapable.Blocks.Generic (toAbort)
+import Data.Functor       (($>))
 import Data.Text          (Text)
 import GHC.Generics       (Generic(..), K1(..), M1(..), (:*:)(..))
 import Text.Parsec
@@ -252,10 +251,10 @@ Error Reports provide positional information of the error in the input form.
 The embedded value will be undefined in case of a `ParseError`.
 -}
 useParser
-  :: (Monad m, OutputCapable (ReportT o m))
+  :: (Monad m, OutputCapable m)
   => Parser a
   -> String
-  -> LangM' (ReportT o m) a
+  -> LangM' m a
 useParser p = useParserAnd p pure
 
 
@@ -267,13 +266,13 @@ The embedded value will be undefined in case of a `ParseError`.
 The provided function will not be applied to the value in this case.
 -}
 useParserAnd
-  :: (Monad m, OutputCapable (ReportT o m))
+  :: (Monad m, OutputCapable m)
   => Parser a
-  -> (a -> LangM' (ReportT o m) b)
+  -> (a -> LangM' m b)
   -> String
-  -> LangM' (ReportT o m) b
+  -> LangM' m b
 useParserAnd p f input = case parse p "" input of
-  Left err      -> toAbort $ refuse $ code $ showWithFieldNumber input err
+  Left err      -> refuse (code $ showWithFieldNumber input err) $> undefined
   Right success -> f success
 
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -26,7 +26,6 @@ import Control.OutputCapable.Blocks (
   translate,
   )
 import Control.OutputCapable.Blocks.Generic (
-  ($>>=),
   toAbort,
   )
 import Data.Map           (Map)

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -336,23 +336,15 @@ parseWithMessaging parser messaging = parseWithFallback parser (const messaging)
 
 showWithFieldNumber :: String -> ParseError -> State (Map Language String) ()
 showWithFieldNumber input e = do
-    german $ "Fehler in Eingabefeld " ++ fieldNum ++ ":" ++ errorsDe
-    english $ "Error in input field " ++ fieldNum ++ ":" ++ errorsEng
+    german $ "Fehler in Eingabefeld " ++ fieldNum ++ ":" ++ errors
+    english $ "Error in input field " ++ fieldNum ++ ":" ++ errors
   where
     fieldNum = show $ length (filter (=='\a') consumed) `div` 2 + 1
-    messages = errorMessages e
-    errorsEng = showErrorMessages
+    errors = showErrorMessages
       "or"
       "unknown parse error"
       "expecting"
       "unexpected"
       "end of input"
-      messages
-    errorsDe = showErrorMessages
-      "oder"
-      "Unbekannter Parserfehler"
-      "erwarte"
-      "unerwartetes"
-      "Ende der Eingabe"
-      messages
+      $ errorMessages e
     consumed = take (sourceColumn $ errorPos e) input

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -246,8 +246,9 @@ parseText t = string $ T.unpack t
 
 {- |
 Parses a String with the given parser and embeds the result into the `OutputCapable` interface.
-Reports a `ParseError` via `reject` primitive instead.
-Error Reports also provide positional information of the error in the input form.
+Reports a `ParseError` via `refuse` primitive instead.
+Error Reports provide positional information of the error in the input form.
+The embedded value will be undefined in case of a `ParseError`.
 -}
 useParser :: OutputCapable m => Parser a -> String -> LangM' m a
 useParser p = useParserAnd p pure
@@ -255,8 +256,10 @@ useParser p = useParserAnd p pure
 
 
 {- |
-Like `useParser` but also applies a processing function to the parse result.
+Like `useParser` but also applies a processing function to the parse result, if it succeeds.
 The function should embed its final output into the `OutputCapable` interface.
+The embedded value will be undefined in case of a `ParseError`.
+The provided function will not be applied to the value in this case.
 -}
 useParserAnd :: OutputCapable m => Parser a -> (a -> LangM' m b) -> String -> LangM' m b
 useParserAnd p f input = case parse p "" input of

--- a/flex-tasks/src/FlexTask/InterpreterHelper.hs
+++ b/flex-tasks/src/FlexTask/InterpreterHelper.hs
@@ -1,16 +1,13 @@
-
+{-# language ApplicativeDo #-}
 module FlexTask.InterpreterHelper (syntaxAndSemantics) where
 
 
-import Control.OutputCapable.Blocks     (LangM, Rated, ReportT, code, refuse)
+import Control.OutputCapable.Blocks     (LangM, LangM', Rated, ReportT)
 import Control.OutputCapable.Blocks.Type
-import Data.Either                      (fromRight)
-import Text.Parsec                      (ParseError, sourceColumn)
-import Text.Parsec.Error (
-  errorMessages,
-  errorPos,
-  showErrorMessages,
+import Control.OutputCapable.Blocks.Generic (
+  ($>>=),
   )
+import Data.Either                      (fromRight)
 
 
 
@@ -18,42 +15,25 @@ type Report = ReportT Output IO
 
 
 syntaxAndSemantics
-  :: (String -> Either ParseError b)
+  :: (String -> Either (LangM Report) (LangM' Report b))
   -> (a -> FilePath -> b -> LangM Report)
   -> (a -> FilePath -> b -> Rated Report)
   -> String
   -> a
   -> FilePath
   -> IO ([Output], Maybe (Maybe Rational, [Output]))
-syntaxAndSemantics parser syntax semantics input tData path  = do
+syntaxAndSemantics preprocess syntax semantics input tData path  = do
   let
-    parsed = parser input
-    syn = either
-      (refuse . code . showWithFieldNumber input)
-      (syntax tData path)
-      parsed
+    parserRes = preprocess input
+    syn = either id ($>>= syntax tData path) parserRes
   synRes <- getOutputSequence syn
   if any isAbort synRes
     then
       pure (synRes,Nothing)
     else do
-      let sem = semantics tData path (fromRight undefined parsed)
+      let sem = fromRight undefined parserRes $>>= semantics tData path
       semRes <- getOutputSequenceWithRating sem
       pure (synRes, Just semRes)
-
-
-showWithFieldNumber :: String -> ParseError -> String
-showWithFieldNumber input e = "Error in input field " ++ fieldNum ++ ":" ++ errors
-  where
-    fieldNum = show $ length (filter (=='\a') consumed) `div` 2 + 1
-    errors = showErrorMessages
-      "or"
-      "unknown parse error"
-      "expecting"
-      "unexpected"
-      "end of input"
-      $ errorMessages e
-    consumed = take (sourceColumn $ errorPos e) input
 
 
 isAbort :: Output -> Bool

--- a/flex-tasks/src/FlexTask/InterpreterHelper.hs
+++ b/flex-tasks/src/FlexTask/InterpreterHelper.hs
@@ -10,7 +10,7 @@ import Control.OutputCapable.Blocks.Type (
   getOutputSequenceWithRating,
   withRefusal,
   )
-import Data.Maybe (fromMaybe)
+import Data.Maybe                       (fromMaybe)
 
 
 

--- a/flex-tasks/src/FlexTask/InterpreterHelper.hs
+++ b/flex-tasks/src/FlexTask/InterpreterHelper.hs
@@ -7,7 +7,6 @@ import Control.OutputCapable.Blocks.Type
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import Data.Either                      (fromRight)
 
 
 
@@ -15,7 +14,7 @@ type Report = ReportT Output IO
 
 
 syntaxAndSemantics
-  :: (String -> Either (LangM Report) (LangM' Report b))
+  :: (String -> LangM' Report b)
   -> (a -> FilePath -> b -> LangM Report)
   -> (a -> FilePath -> b -> Rated Report)
   -> String
@@ -25,13 +24,13 @@ syntaxAndSemantics
 syntaxAndSemantics preprocess syntax semantics input tData path  = do
   let
     parserRes = preprocess input
-    syn = either id ($>>= syntax tData path) parserRes
+    syn = parserRes $>>= syntax tData path
   synRes <- getOutputSequence syn
   if any isAbort synRes
     then
       pure (synRes,Nothing)
     else do
-      let sem = fromRight undefined parserRes $>>= semantics tData path
+      let sem = parserRes $>>= semantics tData path
       semRes <- getOutputSequenceWithRating sem
       pure (synRes, Just semRes)
 

--- a/flex-tasks/src/FlexTask/InterpreterHelper.hs
+++ b/flex-tasks/src/FlexTask/InterpreterHelper.hs
@@ -38,4 +38,4 @@ syntaxAndSemantics preprocess syntax semantics input tData path  = do
 
 
 hasAbort :: [Output] -> Bool
-hasAbort = any $ withRefusal $ const True
+hasAbort = any $ withRefusal $ const False

--- a/flex-tasks/src/FlexTask/InterpreterHelper.hs
+++ b/flex-tasks/src/FlexTask/InterpreterHelper.hs
@@ -10,7 +10,6 @@ import Control.OutputCapable.Blocks.Type (
   getOutputSequenceWithRating,
   withRefusal,
   )
-import Data.Maybe                       (fromMaybe)
 
 
 
@@ -27,10 +26,9 @@ syntaxAndSemantics
   -> IO ([Output], Maybe (Maybe Rational, [Output]))
 syntaxAndSemantics preprocess syntax semantics input tData path  = do
   (mParseResult,parseOutput) <- getOutputSequenceAndResult $ preprocess input
-  if hasAbort parseOutput
-    then pure (parseOutput,Nothing)
-    else do
-      let parseResult = getResult mParseResult
+  case mParseResult of
+    Nothing          -> pure (parseOutput,Nothing)
+    Just parseResult -> do
       synRes <- getOutputSequence (syntax tData path parseResult)
       let parseAndSyntax = parseOutput ++ synRes
       if hasAbort synRes
@@ -39,8 +37,6 @@ syntaxAndSemantics preprocess syntax semantics input tData path  = do
           let sem = semantics tData path parseResult
           semRes <- getOutputSequenceWithRating sem
           pure (parseAndSyntax, Just semRes)
-  where
-    getResult = fromMaybe (error "Result must be Just if output didn't abort!")
 
 
 

--- a/pkgdb-config/stack.yaml
+++ b/pkgdb-config/stack.yaml
@@ -4,7 +4,7 @@ packages:
   - .
 extra-deps:
   - git: https://github.com/fmidue/flex-tasks.git
-    commit: 52bd5135b075ac1968b978ca764c30f65320e360
+    commit: 01db994d2125647af01178b3b2ccf8c8181c07b3
     subdirs:
       - flex-tasks
       - flex-tasks-processing
@@ -13,7 +13,7 @@ extra-deps:
     subdirs:
       - output-blocks
   - git: https://github.com/fmidue/logic-tasks.git
-    commit: 186d62d731ef751f84c92bbc4d4ae34f0a2cd593
+    commit: d88f11aec2821d04287a72f1d1373b3866cce42e
   - git: https://github.com/fmidue/term-tasks
     commit: 1786d63d34d0f4e130b34b32b1acf0099b5c41e0
   - latex-svg-image-0.2@sha256:b282a74a96724037ec3d24b664118e51170c8152aff12f363ddb715a38ef053a,1830

--- a/pkgdb-config/stack.yaml
+++ b/pkgdb-config/stack.yaml
@@ -9,7 +9,7 @@ extra-deps:
       - flex-tasks
       - flex-tasks-processing
   - git: https://github.com/fmidue/output-blocks.git
-    commit: f14dca13e3fa06858ee6299333764b9b89d820c9
+    commit: 292954d4803d80e0bed91cb11294a886361ac2a5
     subdirs:
       - output-blocks
   - git: https://github.com/fmidue/logic-tasks.git

--- a/stack.yaml
+++ b/stack.yaml
@@ -5,6 +5,6 @@ packages:
   - flex-tasks-processing
 extra-deps:
   - git: https://github.com/fmidue/output-blocks.git
-    commit: f14dca13e3fa06858ee6299333764b9b89d820c9
+    commit: 15eec5a92d4d372233dc1180f0d68beb9d42fe9d
     subdirs:
       - output-blocks

--- a/tasks/TermsMined.txt
+++ b/tasks/TermsMined.txt
@@ -269,6 +269,7 @@ module Parse (parseSubmission) where
 import Control.OutputCapable.Blocks (
   LangM',
   OutputCapable,
+  ReportT,
   )
 import FlexTask.Generic.Parse  (parseInput, useParser)
 
@@ -276,5 +277,8 @@ import Global
 
 
 
-parseSubmission :: OutputCapable m => String -> LangM' m Solution
+parseSubmission ::
+  (Monad m, OutputCapable (ReportT o m))
+  => String
+  -> LangM' (ReportT o m) Solution
 parseSubmission = useParser parseInput

--- a/tasks/TermsMined.txt
+++ b/tasks/TermsMined.txt
@@ -265,12 +265,16 @@ description _ = TD.description False
 
 module Parse (parseSubmission) where
 
+
+import Control.OutputCapable.Blocks (
+  LangM',
+  OutputCapable,
+  )
 import FlexTask.Generic.Parse  (parseInput, useParser)
-import Text.Parsec             (ParseError)
 
 import Global
 
 
 
-parseSubmission :: String -> Either ParseError Solution
+parseSubmission :: OutputCapable m => String -> LangM' m Solution
 parseSubmission = useParser parseInput

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -157,21 +157,21 @@ import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   withDelayedReportOrSucceed,
   )
-import LogicTasks.Parsing (formulaListSymbolParser, parser)
+import LogicTasks.Parsing (formulaSymbolParser, parser)
 
 import Global
 
-
-toListString :: (String,String) -> String
-toListString (x,y) = '[' : x ++ ',' : y ++ "]"
 
 parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission input = useParser parseInput input $>>=
-  withDelayedReportOrSucceed
-    parser
-    complainAboutMissingParenthesesIfNotFailingOn
-    formulaListSymbolParser
-    . toListString
+parseSubmission input = useParser parseInput input $>>= \(input1,input2) ->
+  parseWithFallback input1 $>>= \formula1 ->
+    parseWithFallback input2 $>>= \formula2 ->
+      pure [formula1,formula2]
+  where
+    parseWithFallback = withDelayedReportOrSucceed
+      parser
+      complainAboutMissingParenthesesIfNotFailingOn
+      formulaSymbolParser

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -144,10 +144,14 @@ description path inst@ComposeFormulaInst{..} = do
 
 module Parse (parseSubmission) where
 
+
+import Control.OutputCapable.Blocks (
+  LangM',
+  OutputCapable,
+  )
 import FlexTask.Generic.Parse  (parseInput, useParser)
-import Text.Parsec             (ParseError)
 
 import Global
 
-parseSubmission :: String -> Either ParseError Solution
+parseSubmission :: OutputCapable m => String -> LangM' m Solution
 parseSubmission = useParser parseInput

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -152,10 +152,9 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import FlexTask.Generic.Parse  (parseInput, useParser)
+import FlexTask.Generic.Parse  (parseInput, parseWithFallback, useParser)
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
-  withDelayedReportOrSucceed,
   )
 import LogicTasks.Parsing (formulaSymbolParser, parser)
 
@@ -167,11 +166,11 @@ parseSubmission ::
   => String
   -> LangM' (ReportT o m) Solution
 parseSubmission input = useParser parseInput input $>>= \(input1,input2) ->
-  parseWithFallback input1 $>>= \formula1 ->
-    parseWithFallback input2 $>>= \formula2 ->
+  parseIt input1 $>>= \formula1 ->
+    parseIt input2 $>>= \formula2 ->
       pure [formula1,formula2]
   where
-    parseWithFallback = withDelayedReportOrSucceed
+    parseIt = parseWithFallback
       parser
       complainAboutMissingParenthesesIfNotFailingOn
       formulaSymbolParser

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -1,6 +1,8 @@
 module Global where
 
-type Solution = (String,String)
+import Trees.Types (BinOp(..), SynTree(..), TreeFormulaAnswer)
+
+type Solution = [TreeFormulaAnswer]
 
 =============================================
 
@@ -66,7 +68,7 @@ fields :: [[FieldInfo]]
 fields = [[single "Erste Formel:", single "Zweite Formel:"]]
 
 form :: Rendered
-form = formify (Nothing :: Maybe Solution) fields
+form = formify (Nothing :: Maybe (String,String)) fields
 
 checkers :: String
 checkers = [i|
@@ -78,15 +80,12 @@ module Check where
 import Control.Monad.IO.Class           (MonadIO)
 import Control.OutputCapable.Blocks
 import Data.Functor                     (($>))
-import Formula.Parsing.Delayed          (delayed)
-import LogicTasks.Syntax.ComposeFormula (partialGrade, completeGrade)
+import LogicTasks.Syntax.ComposeFormula (partialGrade', completeGrade')
 import Tasks.ComposeFormula.Config      (ComposeFormulaInst(..))
 import Trees.Types                      (BinOp(..), SynTree(..), TreeFormulaAnswer)
 
 import Global
 
-toListString :: (String,String) -> String
-toListString (x,y) = '[' : x ++ ',' : y ++ "]"
 
 checkSyntax
   :: (MonadIO m, OutputCapable m)
@@ -94,7 +93,7 @@ checkSyntax
   -> FilePath
   -> Solution
   -> LangM m
-checkSyntax inst _ try = partialGrade inst $ delayed $ toListString try
+checkSyntax inst _ = partialGrade' inst
 
 checkSemantics
   :: (MonadIO m, OutputCapable m)
@@ -102,7 +101,7 @@ checkSemantics
   -> FilePath
   -> Solution
   -> Rated m
-checkSemantics inst path try = completeGrade path inst (delayed $ toListString try) $> 1.0
+checkSemantics inst path try = completeGrade' path inst try $> 1.0
 
 |]
 
@@ -148,10 +147,31 @@ module Parse (parseSubmission) where
 import Control.OutputCapable.Blocks (
   LangM',
   OutputCapable,
+  ReportT,
+  )
+import Control.OutputCapable.Blocks.Generic (
+  ($>>=),
   )
 import FlexTask.Generic.Parse  (parseInput, useParser)
+import Formula.Parsing.Delayed (
+  complainAboutMissingParenthesesIfNotFailingOn,
+  withDelayedReportOrSucceed,
+  )
+import LogicTasks.Parsing (formulaListSymbolParser, parser)
 
 import Global
 
-parseSubmission :: OutputCapable m => String -> LangM' m Solution
-parseSubmission = useParser parseInput
+
+toListString :: (String,String) -> String
+toListString (x,y) = '[' : x ++ ',' : y ++ "]"
+
+parseSubmission ::
+  (Monad m, OutputCapable (ReportT o m))
+  => String
+  -> LangM' (ReportT o m) Solution
+parseSubmission input = useParser parseInput input $>>=
+  withDelayedReportOrSucceed
+    parser
+    complainAboutMissingParenthesesIfNotFailingOn
+    formulaListSymbolParser
+    . toListString

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -389,18 +389,19 @@ description _ ((legend,hints),_) = do
 module Parse (parseSubmission) where
 
 
-import Control.OutputCapable.Blocks (LangM', OutputCapable)
+import Control.OutputCapable.Blocks (LangM', OutputCapable, ReportT)
+import Control.OutputCapable.Blocks.Generic (($>>=))
 import Data.List.Extra        (chunksOf, intercalate, transpose)
 import FlexTask.Generic.Parse (
   Parse(..),
   parseInstanceMultiChoice,
   escaped,
-  useParserAnd,
+  useParser,
   )
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   delayed,
-  parseDelayedAbortOrProcess,
+  withDelayedReportOrSucceed,
   )
 import LogicTasks.Formula      (TruthValue)
 import LogicTasks.Parsing      (allSymbolParser, parser)
@@ -433,15 +434,15 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
     formattedTruthValues = transpose $ chunksOf totalColumns values
 
 
-parseSubmission :: OutputCapable m => String -> LangM' m Submission
-parseSubmission =
-    useParserAnd parseInput $ \(headerStrings,columns,formulaString,names) ->
-      parseWithFallBack (stringList headerStrings) $ \parsedHeaders ->
-        parseWithFallBack formulaString $ \parsedFormula ->
+parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
+parseSubmission input =
+    useParser parseInput input $>>= \(headerStrings,columns,formulaString,names) ->
+      parseWithFallBack parser (stringList headerStrings) $>>= \parsedHeaders ->
+        parseWithFallBack parser formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)
   where
-    parseWithFallBack input = parseDelayedAbortOrProcess
-      parser
-      complainAboutMissingParenthesesIfNotFailingOn
-      allSymbolParser
-      $ delayed input
+    parseWithFallBack p =
+      withDelayedReportOrSucceed
+        p
+        complainAboutMissingParenthesesIfNotFailingOn
+        allSymbolParser

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -391,7 +391,7 @@ module Parse (parseSubmission) where
 
 import Control.OutputCapable.Blocks (LangM', OutputCapable, ReportT)
 import Control.OutputCapable.Blocks.Generic (($>>=))
-import Data.List.Extra        (chunksOf, intercalate, transpose)
+import Data.List.Extra        (chunksOf, transpose)
 import FlexTask.Generic.Parse (
   Parse(..),
   parseInstanceMultiChoice,
@@ -400,31 +400,22 @@ import FlexTask.Generic.Parse (
   )
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
-  delayed,
   withDelayedReportOrSucceed,
   )
 import LogicTasks.Formula      (TruthValue)
-import LogicTasks.Parsing      (allSymbolParser, parser)
+import LogicTasks.Parsing      (formulaSymbolParser, parser)
 import Trees.Types             (PropFormula(Atomic))
-import qualified Formula.Parsing as FP
 
 import Global
 
 
 
 instance Parse TruthValue where
-  parseInput = escaped FP.parser
+  parseInput = escaped parser
 
 
 instance Parse [Namen] where
   parseInput = parseInstanceMultiChoice
-
-
-stringList :: [Maybe String] -> String
-stringList xs = '[': intercalate "," (map stringMaybe xs) ++ "]"
-  where
-    stringMaybe Nothing = "Nothing"
-    stringMaybe (Just s) = s
 
 
 makeTable :: [Maybe (PropFormula Char)] -> [Maybe TruthValue] -> Table
@@ -437,7 +428,7 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
 parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
 parseSubmission input =
     useParser parseInput input $>>= \(headerStrings,columns,formulaString,names) ->
-      parseWithFallBack parser (stringList headerStrings) $>>= \parsedHeaders ->
+      traverse (maybe (pure Nothing) (fmap Just . parseWithFallBack parser)) headerStrings $>>= \parsedHeaders ->
         parseWithFallBack parser formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)
   where
@@ -445,4 +436,4 @@ parseSubmission input =
       withDelayedReportOrSucceed
         p
         complainAboutMissingParenthesesIfNotFailingOn
-        allSymbolParser
+        formulaSymbolParser

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -309,7 +309,7 @@ checkSyntax _ _ (Table xs,f,n) = do
       "Tabellenspalten existieren nur einmal?"
     assertion (not (null n)) $ bothLangs
       "Es wurde mindestens ein Name angekreuzt? (Alleine gehen ist ausgeschlossen.)"
-    pure undefined
+    pure ()
   where
     fs = map fst xs
     entered = dropStatic fs

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -396,11 +396,11 @@ import FlexTask.Generic.Parse (
   Parse(..),
   parseInstanceMultiChoice,
   escaped,
+  parseWithFallback,
   useParser,
   )
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
-  withDelayedReportOrSucceed,
   )
 import LogicTasks.Formula      (TruthValue)
 import LogicTasks.Parsing      (formulaSymbolParser, parser)
@@ -428,12 +428,12 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
 parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
 parseSubmission input =
     useParser parseInput input $>>= \(headerStrings,columns,formulaString,names) ->
-      traverse (traverse parseWithFallBack) headerStrings $>>= \parsedHeaders ->
-        parseWithFallBack formulaString $>>= \parsedFormula ->
+      traverse (traverse parseIt) headerStrings $>>= \parsedHeaders ->
+        parseIt formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)
   where
-    parseWithFallBack =
-      withDelayedReportOrSucceed
+    parseIt =
+      parseWithFallback
         parser
         complainAboutMissingParenthesesIfNotFailingOn
         formulaSymbolParser

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -428,12 +428,12 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
 parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
 parseSubmission input =
     useParser parseInput input $>>= \(headerStrings,columns,formulaString,names) ->
-      traverse (traverse $ parseWithFallBack parser) headerStrings $>>= \parsedHeaders ->
-        parseWithFallBack parser formulaString $>>= \parsedFormula ->
+      traverse (traverse parseWithFallBack) headerStrings $>>= \parsedHeaders ->
+        parseWithFallBack formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)
   where
-    parseWithFallBack p =
+    parseWithFallBack =
       withDelayedReportOrSucceed
-        p
+        parser
         complainAboutMissingParenthesesIfNotFailingOn
         formulaSymbolParser

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -323,7 +323,7 @@ checkSemantics (_,nSol) _ (Table xs,f,n) = do
     let subFormulas = all (`isSubFormula` f) $ catMaybes $ dropStatic headers
     #{checkType} subFormulas $ bothLangs
       "Als Tabellenspalten kommen nur Teilformeln der Gesamtformel vor?"
-    let correctValues = all correctColumn [(sf,b)| (Just sf,b) <- dropStatic $ zip headers columns]
+    let correctValues = all correctColumn [(sf,b)| (Just sf,b) <- dropStatic xs]
     #{checkType} correctValues $ bothLangs
       "Tabellenspalten enthalten nur korrekt ermittelte Wahrheitswerte?"
     yesNo (T.all (`elem` f) "ABCD") $ bothLangs

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -6,13 +6,13 @@ import LogicTasks.Formula (TruthValue(..))
 import Trees.Types (PropFormula)
 
 
-newtype Table a = Table [(Maybe a, [Maybe TruthValue])] deriving (Eq,Show)
+newtype Table = Table [(Maybe (PropFormula Char), [Maybe TruthValue])] deriving (Eq,Show)
 
 data Namen = A | B | C | D deriving (Eq,Enum,Bounded,Show)
 
 type FormType = (String,[Namen])
 
-type Submission = (Table (PropFormula Char),PropFormula Char,[Namen])
+type Submission = (Table,PropFormula Char,[Namen])
 
 
 emptyColumns, staticColumns, totalColumns, rows :: Int
@@ -245,14 +245,12 @@ module Check (checkSemantics, checkSyntax) where
 import Control.Monad (when)
 import Control.OutputCapable.Blocks
 import Data.Foldable (toList)
-import Data.List     (intercalate, isInfixOf)
+import Data.List     (isInfixOf)
 import Data.Maybe    (catMaybes, fromJust)
 import Data.Map      (fromList)
 import Data.Ratio    ((%))
 
 import LogicTasks.Formula (TruthValue(..), isSemanticEqual, convert)
-import LogicTasks.Parsing (allSymbolParser, parser)
-import Formula.Parsing.Delayed
 import Trees.Types (SynTree(..), PropFormula(..), BinOp(..))
 import Trees.Print (simplestDisplay)
 
@@ -391,20 +389,22 @@ description _ ((legend,hints),_) = do
 module Parse (parseSubmission) where
 
 
-import Control.OutputCapable.Blocks (LangM, LangM', OutputCapable)
-import Data.List               (intercalate, transpose)
-import Data.List.Split         (chunksOf)
+import Control.OutputCapable.Blocks (LangM', OutputCapable)
+import Data.List.Extra        (chunksOf, intercalate, transpose)
 import FlexTask.Generic.Parse (
   Parse(..),
   parseInstanceMultiChoice,
   escaped,
-  useParserAnd
+  useParserAnd,
+  )
+import Formula.Parsing.Delayed (
+  complainAboutMissingParenthesesIfNotFailingOn,
+  delayed,
+  parseDelayedAbortOrProcess,
   )
 import LogicTasks.Formula      (TruthValue)
-import Text.Parsec             (ParseError)
-import Trees.Parsing           ()
 import LogicTasks.Parsing      (allSymbolParser, parser)
-import Formula.Parsing.Delayed
+import Trees.Types             (PropFormula(Atomic))
 import qualified Formula.Parsing as FP
 
 import Global
@@ -419,14 +419,6 @@ instance Parse [Namen] where
   parseInput = parseInstanceMultiChoice
 
 
-
-instance Parse (Table String) where
-  parseInput = do
-    (headers,values) <- parseInput
-    let allHeaders = map (Just . (:[])) "ABCD" ++ headers
-    pure $ Table $ zip allHeaders $ transpose $ chunksOf totalColumns values
-
-
 stringList :: [Maybe String] -> String
 stringList xs = '[': intercalate "," (map stringMaybe xs) ++ "]"
   where
@@ -434,16 +426,22 @@ stringList xs = '[': intercalate "," (map stringMaybe xs) ++ "]"
     stringMaybe (Just s) = s
 
 
-parseSubmission :: OutputCapable m => String -> LangM' m Submission
-parseSubmission = useParserAnd parseInput $ \(Table xs,formula,names) ->
-    let (headers,columns) = unzip xs in
-    parseWithFallBack (stringList headers) $ \x ->
-      parseWithFallBack formula $ \y ->
-        pure (Table (zip x columns),y,names)
+makeTable :: [Maybe (PropFormula Char)] -> [Maybe TruthValue] -> Table
+makeTable headers values = Table $ zip allHeaders formattedTruthValues
   where
-    parseWithFallBack input whatToDo = parseDelayedAbortOrProcess
+    allHeaders = map (Just . Atomic) "ABCD" ++ headers
+    formattedTruthValues = transpose $ chunksOf totalColumns values
+
+
+parseSubmission :: OutputCapable m => String -> LangM' m Submission
+parseSubmission =
+    useParserAnd parseInput $ \(headerStrings,columns,formulaString,names) ->
+      parseWithFallBack (stringList headerStrings) $ \parsedHeaders ->
+        parseWithFallBack formulaString $ \parsedFormula ->
+          pure (makeTable parsedHeaders columns, parsedFormula, names)
+  where
+    parseWithFallBack input = parseDelayedAbortOrProcess
       parser
       complainAboutMissingParenthesesIfNotFailingOn
       allSymbolParser
-      (delayed input)
-      whatToDo
+      $ delayed input

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -3,19 +3,16 @@ module Global where
 
 import Control.OutputCapable.Blocks
 import LogicTasks.Formula (TruthValue(..))
+import Trees.Types (PropFormula)
 
 
-
-instance Eq TruthValue where
-  (TruthValue a) == (TruthValue b) = a == b
-
-newtype Table = Table [(Maybe String, [Maybe TruthValue])] deriving (Eq,Show)
+newtype Table a = Table [(Maybe a, [Maybe TruthValue])] deriving (Eq,Show)
 
 data Namen = A | B | C | D deriving (Eq,Enum,Bounded,Show)
 
 type FormType = (String,[Namen])
 
-type Submission = (Table,String,[Namen])
+type Submission = (Table (PropFormula Char),PropFormula Char,[Namen])
 
 
 emptyColumns, staticColumns, totalColumns, rows :: Int
@@ -284,16 +281,6 @@ isSubFormula a b = noSpaces a `isInfixOf` noSpaces b
     noSpaces = filter (/=' ') . show
 
 
-stringTuple :: String -> String -> String
-stringTuple s1 s2 = '(':s1 ++ ',':s2 ++ ")"
-
-
-stringList :: [Maybe String] -> String
-stringList xs = '[': intercalate "," (map stringMaybe xs) ++ "]"
-  where
-    stringMaybe Nothing = "Nothing"
-    stringMaybe (Just s) = s
-
 
 toTree :: PropFormula Char -> SynTree BinOp Char
 toTree (Atomic c) = Leaf c
@@ -307,18 +294,7 @@ dropStatic = drop staticColumns
 
 
 checkSyntax :: OutputCapable m => a -> FilePath -> Submission -> LangM m
-checkSyntax _ _ (Table xs,formula,names) =
-  parseDelayedWithAndThen
-    parser
-    complainAboutMissingParenthesesIfNotFailingOn
-    allSymbolParser
-    (checkSyntax' names)
-    $ delayed $ stringTuple (stringList $ map fst xs) formula
-
-
-
-checkSyntax' :: OutputCapable m => [Namen] -> ([Maybe (PropFormula Char)],PropFormula Char) -> LangM m
-checkSyntax' n (fs,f) = do
+checkSyntax _ _ (Table xs,f,n) = do
     paragraph $ do
       bothLangs $ do
         "Es wurden Formeln wie folgt gelesen:"
@@ -335,24 +311,14 @@ checkSyntax' n (fs,f) = do
       "Tabellenspalten existieren nur einmal?"
     assertion (not (null n)) $ bothLangs
       "Es wurde mindestens ein Name angekreuzt? (Alleine gehen ist ausgeschlossen.)"
-    pure ()
+    pure undefined
   where
+    fs = map fst xs
     entered = dropStatic fs
 
 
 checkSemantics :: OutputCapable m => (a,[Namen]) -> FilePath -> Submission -> Rated m
-checkSemantics (_,nSol) _ (Table xs,formula,names) =
-  withDelayedSucceeding
-    (checkSemantics' nSol columns names)
-    parser
-    $ delayed $ stringTuple (stringList headers) formula
-  where
-    (headers,columns) = unzip xs
-
-
-
-checkSemantics' :: OutputCapable m => [Namen] -> [[Maybe TruthValue]] -> [Namen] -> ([Maybe (PropFormula Char)],PropFormula Char) -> Rated m
-checkSemantics' nSol columns n (headers,f) = do
+checkSemantics (_,nSol) _ (Table xs,f,n) = do
     let correctStart = take staticColumns columns == #{startingTable}
     #{checkType} correctStart $ bothLangs
       "Spalten der atomaren Formeln ergeben sinnvolle Wahrheitstafel?"
@@ -375,6 +341,7 @@ checkSemantics' nSol columns n (headers,f) = do
     res <- printSolutionAndAssert IndefiniteArticle maybeAnswer points
     pure res
   where
+    (headers,columns) = unzip xs
     maybeAnswer = flip (++) (show nSol) <$>
                     #{if showSolution
                        then Just ("Formel: " ++ simplestDisplay fSol ++ "\nKorrekte Einträge in Wahrheitstafel.\nBegleitende: ")
@@ -424,18 +391,20 @@ description _ ((legend,hints),_) = do
 module Parse (parseSubmission) where
 
 
-import Data.List               (transpose)
+import Control.OutputCapable.Blocks (LangM, LangM', OutputCapable)
+import Data.List               (intercalate, transpose)
 import Data.List.Split         (chunksOf)
 import FlexTask.Generic.Parse (
   Parse(..),
   parseInstanceMultiChoice,
   escaped,
-  useParser
+  useParserAnd
   )
 import LogicTasks.Formula      (TruthValue)
 import Text.Parsec             (ParseError)
 import Trees.Parsing           ()
-
+import LogicTasks.Parsing      (allSymbolParser, parser)
+import Formula.Parsing.Delayed
 import qualified Formula.Parsing as FP
 
 import Global
@@ -451,13 +420,31 @@ instance Parse [Namen] where
 
 
 
-instance Parse Table where
+instance Parse (Table String) where
   parseInput = do
     (headers,values) <- parseInput
     let allHeaders = map (Just . (:[])) "ABCD" ++ headers
     pure $ Table $ zip allHeaders $ transpose $ chunksOf totalColumns values
 
 
+stringList :: [Maybe String] -> String
+stringList xs = '[': intercalate "," (map stringMaybe xs) ++ "]"
+  where
+    stringMaybe Nothing = "Nothing"
+    stringMaybe (Just s) = s
 
-parseSubmission :: String -> Either ParseError Submission
-parseSubmission = useParser parseInput
+
+parseSubmission :: OutputCapable m => String -> LangM' m Submission
+parseSubmission = useParserAnd parseInput $ \(Table xs,formula,names) -> let (headers,columns) = unzip xs in
+  parseDelayedAbortOrProcess
+    parser
+    complainAboutMissingParenthesesIfNotFailingOn
+    allSymbolParser
+    (delayed $ stringList headers)
+    $ \x -> parseDelayedAbortOrProcess
+              parser
+              complainAboutMissingParenthesesIfNotFailingOn
+              allSymbolParser
+              (delayed formula)
+              (\y -> pure (Table (zip x columns),y,names))
+

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -435,16 +435,15 @@ stringList xs = '[': intercalate "," (map stringMaybe xs) ++ "]"
 
 
 parseSubmission :: OutputCapable m => String -> LangM' m Submission
-parseSubmission = useParserAnd parseInput $ \(Table xs,formula,names) -> let (headers,columns) = unzip xs in
-  parseDelayedAbortOrProcess
-    parser
-    complainAboutMissingParenthesesIfNotFailingOn
-    allSymbolParser
-    (delayed $ stringList headers)
-    $ \x -> parseDelayedAbortOrProcess
-              parser
-              complainAboutMissingParenthesesIfNotFailingOn
-              allSymbolParser
-              (delayed formula)
-              (\y -> pure (Table (zip x columns),y,names))
-
+parseSubmission = useParserAnd parseInput $ \(Table xs,formula,names) ->
+    let (headers,columns) = unzip xs in
+    parseWithFallBack (stringList headers) $ \x ->
+      parseWithFallBack formula $ \y ->
+        pure (Table (zip x columns),y,names)
+  where
+    parseWithFallBack input whatToDo = parseDelayedAbortOrProcess
+      parser
+      complainAboutMissingParenthesesIfNotFailingOn
+      allSymbolParser
+      (delayed input)
+      whatToDo

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -428,7 +428,7 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
 parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
 parseSubmission input =
     useParser parseInput input $>>= \(headerStrings,columns,formulaString,names) ->
-      traverse (maybe (pure Nothing) (fmap Just . parseWithFallBack parser)) headerStrings $>>= \parsedHeaders ->
+      traverse (traverse $ parseWithFallBack parser) headerStrings $>>= \parsedHeaders ->
         parseWithFallBack parser formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)
   where


### PR DESCRIPTION
- Parsing now produces `LangM' m Submission` value 
- The encapsulated value is shared and fed to the check functions
- aborts with reject feedback on parse errors
- Added `useParserAnd` function to allow for further processing, i.e. with `Delayed`