### PR TITLE
revise the parsing API

### DIFF
--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -300,7 +300,11 @@ If you want to chain multiple parsing steps, e.g. with 'parseWithFallback',
 use '$>>=' of 'Control.OutputCapable.Blocks.Generic'.
 This operation can be seen as a '>>=' equivalent for 'LangM''.
 Example:
-'parseWithOrReport parseInput reportWithFieldNumber input $>>= \s -> parseWithFallback (fully p) someFunc (fully fallback) s $>>= pure . ...'
+```
+parseWithOrReport parseInput reportWithFieldNumber input
+  $>>= \s -> parseWithFallback (fully p) someFunc (fully fallback) s
+    $>>= pure . ...
+```
 
 As with forms, a generic parser interface is available.
 The steps are similar:

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -311,7 +311,7 @@ The possible error of the fallback parser and the original error
 are then fed to the messaging function to construct the report.
 Use this to produce more sophisticated error messages.
 A simpler route is to also use just 'parseWithOrReport' in this phase, with
-something like 'const (bothLangs . show)' as the reporting function.
+something like 'const (text . show)' as the reporting function.
 
 If you want to chain multiple parsing steps, e.g. with 'parseWithFallback',
 use '$>>=' of 'Control.OutputCapable.Blocks.Generic'.

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -278,28 +278,29 @@ The final result is passed to the check functions to generate feedback.
 The parsers used throughout are those of 'Text.Parsec'.
 Refer to its documentation if necessary.
 
-To implement parseSubmission, you will typically invoke 'useParser' and
-possibly 'parseWithFallback' or 'parseWithMessage', all
+To implement parseSubmission, you will typically invoke 'parseWithOrReport'
+and 'reportWithFieldNumber', and possibly also 'parseWithFallback', all
 supplied by 'FlexTask.Generic.Parse'. In simple situations, '<&>' may suffice.
-The 'useParser' function takes a parser and the 'String' input as arguments
-and embeds the result directly into 'OutputCapable'.
-This function directly reads the form results.
+Simply using `parseWithOrReport parseInput reportWithFieldNumber` directly
+reads the form inputs and embeds the result directly into 'OutputCapable'.
 It is enough if you do not need additional processing of the input.
 The 'parseWithFallback' function can be used to additionally parse/process
 Strings from among the form result, that is, individual input fields.
-It should be used after 'useParser', instead of on its own.
+It should be used after 'parseWithOrReport parseInput', instead of on its own.
 'parseWithFallback' takes a parser, messaging function, fallback parser and the input.
 The secondary parser is used as a simpler sanity check on the input in case
 of an error with the primary parser.
 The possible error of the fallback parser and the original error
 are then fed to the messaging function to construct the report.
 Use this to produce more sophisticated error messages.
+A simpler route is to also use just 'parseWithOrReport' in this phase, with
+something like 'const (bothLangs . show)' as the reporting function.
 
 If you want to chain multiple parsing steps, e.g. with 'parseWithFallback',
 use '$>>=' of 'Control.OutputCapable.Blocks.Generic'.
 This operation can be seen as a '>>=' equivalent for 'LangM''.
 Example:
-'useParser parseInput input $>>= \s -> parseWithFallback p someFunc fallback s $>>= pure . ...'
+'parseWithOrReport parseInput reportWithFieldNumber input $>>= \s -> parseWithFallback (fully p) someFunc (fully fallback) s $>>= pure . ...'
 
 As with forms, a generic parser interface is available.
 The steps are similar:
@@ -327,7 +328,7 @@ import Control.OutputCapable.Blocks (
   ReportT,
   OutputCapable,
   )
-import FlexTask.Generic.Parse  (parseInput, useParser)
+import FlexTask.Generic.Parse  (parseInput, parseWithOrReport, reportWithFieldNumber)
 
 import Global
 
@@ -337,6 +338,6 @@ parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission = useParser parseInput
+parseSubmission = parseWithOrReport parseInput reportWithFieldNumber
 
 |]

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -319,7 +319,7 @@ This operation can be seen as a '>>=' equivalent for 'LangM''.
 Example:
 ```
 parseWithOrReport formParser reportWithFieldNumber input
-  $>>= \s -> parseWithFallback (fully p) someFunc (fully fallback) s
+  $>>= \s -> parseWithFallback p someFunc fallback s
     $>>= pure . ...
 ```
 

--- a/flex-tasks/src/FlexTask/DefaultConfig.hs
+++ b/flex-tasks/src/FlexTask/DefaultConfig.hs
@@ -298,12 +298,12 @@ Refer to its documentation if necessary.
 To implement parseSubmission, you will typically invoke 'parseWithOrReport'
 and 'reportWithFieldNumber', and possibly also 'parseWithFallback', all
 supplied by 'FlexTask.Generic.Parse'. In simple situations, '<&>' may suffice.
-Simply using `parseWithOrReport parseInput reportWithFieldNumber` directly
+Simply using `parseWithOrReport formParser reportWithFieldNumber` directly
 reads the form inputs and embeds the result directly into 'OutputCapable'.
 It is enough if you do not need additional processing of the input.
 The 'parseWithFallback' function can be used to additionally parse/process
 Strings from among the form result, that is, individual input fields.
-It should be used after 'parseWithOrReport parseInput', instead of on its own.
+It should be used after 'parseWithOrReport formParser', instead of on its own.
 'parseWithFallback' takes a parser, messaging function, fallback parser and the input.
 The secondary parser is used as a simpler sanity check on the input in case
 of an error with the primary parser.
@@ -318,7 +318,7 @@ use '$>>=' of 'Control.OutputCapable.Blocks.Generic'.
 This operation can be seen as a '>>=' equivalent for 'LangM''.
 Example:
 ```
-parseWithOrReport parseInput reportWithFieldNumber input
+parseWithOrReport formParser reportWithFieldNumber input
   $>>= \s -> parseWithFallback (fully p) someFunc (fully fallback) s
     $>>= pure . ...
 ```
@@ -349,7 +349,7 @@ import Control.OutputCapable.Blocks (
   ReportT,
   OutputCapable,
   )
-import FlexTask.Generic.Parse  (parseInput, parseWithOrReport, reportWithFieldNumber)
+import FlexTask.Generic.Parse  (formParser, parseWithOrReport, reportWithFieldNumber)
 
 import Global
 
@@ -359,6 +359,6 @@ parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission = parseWithOrReport parseInput reportWithFieldNumber
+parseSubmission = parseWithOrReport formParser reportWithFieldNumber
 
 |]

--- a/flex-tasks/src/FlexTask/Generic/Parse.hs
+++ b/flex-tasks/src/FlexTask/Generic/Parse.hs
@@ -21,4 +21,4 @@ instance {-# Overlappable #-} TypeError ('Text "Parse instances for nested lists
               ':$$: 'Text "Please use a newtype or custom datatype instead."
                    )
          => Parse [[a]] where
-   parseInput = error "unreachable"
+   formParser = error "unreachable"

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -29,6 +29,7 @@ import Control.OutputCapable.Blocks (
   english,
   german,
   indent,
+  text,
   translate,
   )
 import Control.OutputCapable.Blocks.Generic (
@@ -318,9 +319,12 @@ fully p = spaces *> p <* eof
 Provide error report with positional information relative to an input form.
 -}
 reportWithFieldNumber :: OutputCapable m => String -> ParseError -> LangM m
-reportWithFieldNumber input e = indent $ translate $ do
-    german $ "Fehler in Eingabefeld " ++ fieldNum ++ ":" ++ errors
-    english $ "Error in input field " ++ fieldNum ++ ":" ++ errors
+reportWithFieldNumber input e = indent $ do
+    translate $ do
+      german "Fehler in Eingabefeld"
+      english "Error in input field"
+    text $ " " ++ fieldNum ++ ":" ++ errors
+    pure ()
   where
     fieldNum = show $ length (filter (=='\a') consumed) `div` 2 + 1
     errors = showErrorMessages
@@ -338,8 +342,9 @@ withInput ::
   -> String -> Maybe a -> ParseError -> LangM m
 withInput messaging a ma err = do
   translate $ do
-    german $ "Fehler in \"" ++ a ++ "\" : "
-    english $ "Error in \"" ++ a ++ "\" : "
+    german "Fehler in"
+    english "Error in"
+  text $ " \"" ++ a ++ "\" : "
   indent $ translate $ messaging ma err
   pure ()
 

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -18,6 +18,7 @@ module FlexTask.Generic.ParseInternal
 
 import Control.Monad      (void)
 import Control.OutputCapable.Blocks (
+  LangM,
   LangM',
   OutputCapable,
   ReportT,
@@ -267,7 +268,7 @@ This can be useful for giving better error messages.
 parseWithOrReport ::
   (Monad m, OutputCapable (ReportT o m))
   => Parser a
-  -> (String -> ParseError -> LangM' (ReportT o m) ())
+  -> (String -> ParseError -> LangM (ReportT o m))
   -> String
   -> LangM' (ReportT o m) a
 parseWithOrReport parser errorMsg answer =
@@ -288,7 +289,7 @@ parseWithFallback ::
   (Monad m, OutputCapable (ReportT o m))
   => Parser a
   -- ^ Parser to use initially
-  -> (Maybe ParseError -> ParseError -> LangM' (ReportT o m) ())
+  -> (Maybe ParseError -> ParseError -> LangM (ReportT o m))
   -- ^ How to produce an error report based on:
   -- ^ 1. The possible parse error of the fallback parser
   -- ^ 2. The original parse error
@@ -318,8 +319,7 @@ fully p = spaces *> p <* eof
 {- |
 Provide error report with positional information relative to an input form.
 -}
-reportWithFieldNumber :: (Monad m, OutputCapable (ReportT o m))
-  => String -> ParseError -> LangM' (ReportT o m) ()
+reportWithFieldNumber :: OutputCapable m => String -> ParseError -> LangM m
 reportWithFieldNumber input e = indent $ translate $ do
     german $ "Fehler in Eingabefeld " ++ fieldNum ++ ":" ++ errors
     english $ "Error in input field " ++ fieldNum ++ ":" ++ errors

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -17,9 +17,7 @@ module FlexTask.Generic.ParseInternal
 
 
 import Control.Monad      (void)
-import Control.Monad.State (State)
 import Control.OutputCapable.Blocks (
-  Language,
   LangM,
   LangM',
   OutputCapable,
@@ -33,7 +31,6 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   toAbort,
   )
-import Data.Map           (Map)
 import Data.Text          (Text)
 import GHC.Generics       (Generic(..), K1(..), M1(..), (:*:)(..))
 import Text.Parsec
@@ -339,12 +336,12 @@ reportWithFieldNumber input e = do
 
 displayInputAnd ::
   OutputCapable m =>
-  (Maybe a -> ParseError -> State (Map Language String) ())
+  (Maybe a -> ParseError -> LangM m)
   -> String -> Maybe a -> ParseError -> LangM m
 displayInputAnd messaging a ma err = do
   translate $ do
     german "Fehler in"
     english "Error in"
   text $ " \"" ++ a ++ "\" : "
-  indent $ translate $ messaging ma err
+  indent $ messaging ma err
   pure ()

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -12,8 +12,7 @@ module FlexTask.Generic.ParseInternal
   , parseWithOrReport
   , reportWithFieldNumber
   , parseWithFallback
-  , withInput
-  , withoutInput
+  , displayInputAnd
   ) where
 
 
@@ -338,20 +337,14 @@ reportWithFieldNumber input e = do
       $ errorMessages e
     consumed = take (sourceColumn $ errorPos e) input
 
-withInput ::
+displayInputAnd ::
   OutputCapable m =>
   (Maybe a -> ParseError -> State (Map Language String) ())
   -> String -> Maybe a -> ParseError -> LangM m
-withInput messaging a ma err = do
+displayInputAnd messaging a ma err = do
   translate $ do
     german "Fehler in"
     english "Error in"
   text $ " \"" ++ a ++ "\" : "
   indent $ translate $ messaging ma err
   pure ()
-
-withoutInput ::
-  OutputCapable m =>
-  (Maybe a -> ParseError -> State (Map Language String) ())
-  -> String -> Maybe a -> ParseError -> LangM m
-withoutInput messaging _ ma = translate . messaging ma

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -11,7 +11,6 @@ module FlexTask.Generic.ParseInternal
   , escaped
   , parseWithOrReport
   , reportWithFieldNumber
-  , fully
   , parseWithFallback
   , withInput
   , withoutInput
@@ -42,7 +41,6 @@ import Text.Parsec
   ( ParseError
   , (<|>)
   , between
-  , eof
   , lookAhead
   , manyTill
   , many1
@@ -53,7 +51,7 @@ import Text.Parsec
   , sourceColumn
   , try
   )
-import Text.Parsec.Char   (anyChar, char, digit, spaces, string)
+import Text.Parsec.Char   (anyChar, char, digit, string)
 import Text.Parsec.Error (
   errorMessages,
   errorPos,
@@ -312,8 +310,7 @@ parseWithFallback parser messaging fallBackParser =
     parser
     (\a -> messaging a (either Just (const Nothing) (parse fallBackParser "" a)))
 
-fully :: Parser a -> Parser a
-fully p = spaces *> p <* eof
+
 
 {- |
 Provide error report with positional information relative to an input form.

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -267,6 +267,9 @@ parseText t = string $ T.unpack t
 Parses a String with the given parser and embeds the result into the `OutputCapable` interface.
 No value will be embedded in case of a `ParseError`. Instead, an error report is given then.
 That report is built using the second function argument.
+The report will automatically abort after displaying.
+It is therefore not necessary to include a `refuse`, but it is not harmful either.
+Adding a refuse will display text and cut off any following output as usual.
 This can be useful for giving better error messages.
 -}
 parseWithOrReport ::
@@ -286,6 +289,7 @@ Parses a String with the given parser.
 Allows for further processing of a possible parse error.
 A second parser is used as a fallback in case of an error.
 The result of both parsers is then used to construct the report.
+Comments on `refuse`'s behaviour for `parseWithOrReport` also apply for this function.
 This can be useful for giving more specific error messages,
 e.g. checking a term for bracket consistency even if the parser failed early on.
 -}

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -319,11 +319,12 @@ fully p = spaces *> p <* eof
 Provide error report with positional information relative to an input form.
 -}
 reportWithFieldNumber :: OutputCapable m => String -> ParseError -> LangM m
-reportWithFieldNumber input e = indent $ do
+reportWithFieldNumber input e = do
     translate $ do
       german "Fehler in Eingabefeld"
       english "Error in input field"
-    text $ " " ++ fieldNum ++ ":" ++ errors
+    text $ " " ++ fieldNum ++ ":"
+    indent $ text errors
     pure ()
   where
     fieldNum = show $ length (filter (=='\a') consumed) `div` 2 + 1

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -318,9 +318,8 @@ Provide error report with positional information relative to an input form.
 reportWithFieldNumber :: OutputCapable m => String -> ParseError -> LangM m
 reportWithFieldNumber input e = do
     translate $ do
-      german "Fehler in Eingabefeld"
-      english "Error in input field"
-    text $ " " ++ fieldNum ++ ":"
+      german $ "Fehler in Eingabefeld" ++ " " ++ fieldNum ++ ":"
+      english $ "Error in input field" ++ " " ++ fieldNum ++ ":"
     indent $ text errors
     pure ()
   where
@@ -340,8 +339,7 @@ displayInputAnd ::
   -> String -> Maybe a -> ParseError -> LangM m
 displayInputAnd messaging a ma err = do
   translate $ do
-    german "Fehler in"
-    english "Error in"
-  text $ " \"" ++ a ++ "\" : "
+    german $ "Fehler in" ++  " \"" ++ a ++ "\" : "
+    english $ "Error in" ++ " \"" ++ a ++ "\" : "
   indent $ messaging ma err
   pure ()

--- a/flex-tasks/test/FlexTask/Generic/ParseSpec.hs
+++ b/flex-tasks/test/FlexTask/Generic/ParseSpec.hs
@@ -33,10 +33,10 @@ import FlexTask.Processing.Text         (formatAnswer)
 data TestEnum = One | Two | Three deriving (Bounded, Enum, Eq, Show)
 
 instance Parse TestEnum where
-  parseInput = parseInstanceSingleChoice
+  formParser = parseInstanceSingleChoice
 
 instance Parse [TestEnum] where
-  parseInput = parseInstanceMultiChoice
+  formParser = parseInstanceMultiChoice
 
 
 spec :: Spec
@@ -47,7 +47,7 @@ spec = do
         Left _ -> withParser (escaped testParse) `shouldFailOn` escapedSingle s
         Right res -> withParser (escaped testParse) (escapedSingle s) `shouldParse` stripEscape res
 
-  describe "parseInput" $ do
+  describe "formParser" $ do
     context "should work for all base types" $ do
       prop "String" $ testParsingString id
       prop "Text" $ testParsingString pack
@@ -149,4 +149,4 @@ withParser p = parse p ""
 
 
 parsesTo :: (Show a, Eq a, Parse a) => String -> a -> Expectation
-parsesTo input output = withParser parseInput input `shouldParse` output
+parsesTo input output = withParser formParser input `shouldParse` output

--- a/tasks/TermsMined.txt
+++ b/tasks/TermsMined.txt
@@ -271,7 +271,7 @@ import Control.OutputCapable.Blocks (
   OutputCapable,
   ReportT,
   )
-import FlexTask.Generic.Parse  (parseInput, useParser)
+import FlexTask.Generic.Parse  (parseInput, parseWithOrReport, reportWithFieldNumber)
 
 import Global
 
@@ -281,4 +281,4 @@ parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission = useParser parseInput
+parseSubmission = parseWithOrReport parseInput reportWithFieldNumber

--- a/tasks/TermsMined.txt
+++ b/tasks/TermsMined.txt
@@ -281,7 +281,7 @@ import Control.OutputCapable.Blocks (
   OutputCapable,
   ReportT,
   )
-import FlexTask.Generic.Parse  (parseInput, parseWithOrReport, reportWithFieldNumber)
+import FlexTask.Generic.Parse  (formParser, parseWithOrReport, reportWithFieldNumber)
 
 import Global
 
@@ -291,4 +291,4 @@ parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission = parseWithOrReport parseInput reportWithFieldNumber
+parseSubmission = parseWithOrReport formParser reportWithFieldNumber

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -165,7 +165,7 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import FlexTask.Generic.Parse  (parseInput, parseWithFallback, withInput, fully, parseWithOrReport, reportWithFieldNumber)
+import FlexTask.Generic.Parse  (formParser, parseWithFallback, withInput, fully, parseWithOrReport, reportWithFieldNumber)
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   )
@@ -178,7 +178,7 @@ parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission input = parseWithOrReport parseInput reportWithFieldNumber input $>>= \(input1,input2) ->
+parseSubmission input = parseWithOrReport formParser reportWithFieldNumber input $>>= \(input1,input2) ->
   parseIt input1 $>>= \formula1 ->
     parseIt input2 $>>= \formula2 ->
       pure [formula1,formula2]

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -152,7 +152,7 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import FlexTask.Generic.Parse  (parseInput, parseWithFallback, useParser)
+import FlexTask.Generic.Parse  (parseInput, parseWithFallback, fully, parseWithOrReport, reportWithFieldNumber)
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   )
@@ -165,12 +165,12 @@ parseSubmission ::
   (Monad m, OutputCapable (ReportT o m))
   => String
   -> LangM' (ReportT o m) Solution
-parseSubmission input = useParser parseInput input $>>= \(input1,input2) ->
+parseSubmission input = parseWithOrReport parseInput reportWithFieldNumber input $>>= \(input1,input2) ->
   parseIt input1 $>>= \formula1 ->
     parseIt input2 $>>= \formula2 ->
       pure [formula1,formula2]
   where
     parseIt = parseWithFallback
-      parser
+      (fully parser)
       complainAboutMissingParenthesesIfNotFailingOn
-      formulaSymbolParser
+      (fully formulaSymbolParser)

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -165,7 +165,13 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import FlexTask.Generic.Parse  (formParser, parseWithFallback, withInput, parseWithOrReport, reportWithFieldNumber)
+import FlexTask.Generic.Parse (
+  displayInputAnd,
+  formParser,
+  parseWithFallback,
+  parseWithOrReport,
+  reportWithFieldNumber,
+  )
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   )
@@ -186,5 +192,5 @@ parseSubmission input = parseWithOrReport formParser reportWithFieldNumber input
   where
     parseIt = parseWithFallback
       (fully parser)
-      (withInput complainAboutMissingParenthesesIfNotFailingOn)
+      (displayInputAnd complainAboutMissingParenthesesIfNotFailingOn)
       (fully formulaSymbolParser)

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -152,7 +152,7 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import FlexTask.Generic.Parse  (parseInput, parseWithFallback, fully, parseWithOrReport, reportWithFieldNumber)
+import FlexTask.Generic.Parse  (parseInput, parseWithFallback, withInput, fully, parseWithOrReport, reportWithFieldNumber)
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   )
@@ -172,5 +172,5 @@ parseSubmission input = parseWithOrReport parseInput reportWithFieldNumber input
   where
     parseIt = parseWithFallback
       (fully parser)
-      complainAboutMissingParenthesesIfNotFailingOn
+      (withInput complainAboutMissingParenthesesIfNotFailingOn)
       (fully formulaSymbolParser)

--- a/tasks/composeFormula.txt
+++ b/tasks/composeFormula.txt
@@ -165,11 +165,12 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   ($>>=),
   )
-import FlexTask.Generic.Parse  (formParser, parseWithFallback, withInput, fully, parseWithOrReport, reportWithFieldNumber)
+import FlexTask.Generic.Parse  (formParser, parseWithFallback, withInput, parseWithOrReport, reportWithFieldNumber)
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
   )
 import LogicTasks.Parsing (formulaSymbolParser, parser)
+import ParsingHelpers          (fully)
 
 import Global
 

--- a/tasks/interpolation-test/slowTaskInterpolation.txt
+++ b/tasks/interpolation-test/slowTaskInterpolation.txt
@@ -116,7 +116,7 @@ description _ input = do
 module Parse (parseSubmission) where
 
 
-import FlexTask.Generic.Parse  (parseInput, useParser)
+import FlexTask.Generic.Parse  (parseInput, parseWithOrReport, reportWithFieldNumber)
 import Text.Parsec             (ParseError)
 
 import Global
@@ -125,4 +125,4 @@ import Global
 
 
 parseSubmission :: String -> Either ParseError Solution
-parseSubmission = useParser parseInput
+parseSubmission = parseWithOrReport parseInput reportWithFieldNumber

--- a/tasks/interpolation-test/treeInterpolation.txt
+++ b/tasks/interpolation-test/treeInterpolation.txt
@@ -124,7 +124,7 @@ description _ input = do
 module Parse (parseSubmission) where
 
 
-import FlexTask.Generic.Parse  (parseInput, useParser)
+import FlexTask.Generic.Parse  (parseInput, parseWithOrReport, reportWithFieldNumber)
 import Text.Parsec             (ParseError)
 
 import Global
@@ -133,5 +133,5 @@ import Global
 
 
 parseSubmission :: String -> Either ParseError Solution
-parseSubmission = useParser parseInput
+parseSubmission = parseWithOrReport parseInput reportWithFieldNumber
 

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -397,7 +397,9 @@ import FlexTask.Generic.Parse (
   parseInstanceMultiChoice,
   escaped,
   parseWithFallback,
-  useParser,
+  fully,
+  parseWithOrReport,
+  reportWithFieldNumber,
   )
 import Formula.Parsing.Delayed (
   complainAboutMissingParenthesesIfNotFailingOn,
@@ -427,13 +429,13 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
 
 parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
 parseSubmission input =
-    useParser parseInput input $>>= \(headerStrings,columns,formulaString,names) ->
+    parseWithOrReport parseInput reportWithFieldNumber input $>>= \(headerStrings,columns,formulaString,names) ->
       traverse (traverse parseIt) headerStrings $>>= \parsedHeaders ->
         parseIt formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)
   where
     parseIt =
       parseWithFallback
-        parser
+        (fully parser)
         complainAboutMissingParenthesesIfNotFailingOn
-        formulaSymbolParser
+        (fully formulaSymbolParser)

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -2,7 +2,6 @@
 module Global where
 
 
-import Control.OutputCapable.Blocks
 import LogicTasks.Formula (TruthValue)
 import Trees.Types (PropFormula)
 
@@ -26,10 +25,6 @@ rows          = 2^staticColumns
 tableRequired, showSolution :: Bool
 tableRequired = False
 showSolution  = True
-
-
-bothLangs :: OutputCapable m => String -> LangM m
-bothLangs s = translate $ german s >> english s
 
 =============================================
 
@@ -267,33 +262,31 @@ dropStatic = drop staticColumns
 checkSyntax :: OutputCapable m => FilePath -> a -> Submission -> LangM m
 checkSyntax _ _ (Table xs,f,n) = do
     paragraph $ do
-      bothLangs $ do
-        "Es wurden Formeln wie folgt gelesen:"
+      text "Es wurden Formeln wie folgt gelesen:"
       when (any (/=Nothing) mColumns) $ indent $ do
-        bothLangs "Tabellenspalten"
+        text "Tabellenspalten"
         code $ unlines $ map (simplestDisplay . toSynTree) entered
         pure ()
       indent $ do
-        bothLangs "Antwortformel"
+        text "Antwortformel"
         code $ simplestDisplay $ toSynTree f
         pure ()
       pure ()
-    when (atomicColumns == map reverse #{startingTable}) $ refuse $ indent $ bothLangs $
+    when (atomicColumns == map reverse #{startingTable}) $ refuse $ indent $ text $
       "Die Spalten der atomaren Formeln sind invertiert. " ++
       "Bitte legen Sie die Tafel so an wie in der Vorlesung vorgegeben."
-    assertion (nubOrd atomicRows == atomicRows) $ bothLangs
+    assertion (nubOrd atomicRows == atomicRows) $ text
       "Alle vollständig eingetragenen Belegungen kommen nur einmal in Tafel vor?"
-    assertion (notElem 'E' $ concatMap toList $ f : entered) $ bothLangs
+    assertion (notElem 'E' $ concatMap toList $ f : entered) $ text
       "Eva (E) kommt nicht in Formeln vor?"
     assertion (
       all (`elem` ('F': toList (#{fSol}))) (concatMap toList entered) &&
       all (`elem` toList (#{fSol})) (toList f)
       )
-      $ bothLangs
-      "Es wurden nur bekannte atomare Formeln genutzt?"
-    assertion (all noDuplicate entered) $ bothLangs
+      $ text "Es wurden nur bekannte atomare Formeln genutzt?"
+    assertion (all noDuplicate entered) $ text
       "Tabellenspalten existieren nur einmal?"
-    assertion (not (null n)) $ bothLangs
+    assertion (not (null n)) $ text
       "Es wurde mindestens ein Name angekreuzt? (Alleine gehen ist ausgeschlossen.)"
     pure ()
   where
@@ -309,22 +302,20 @@ checkSyntax _ _ (Table xs,f,n) = do
 checkSemantics :: OutputCapable m => FilePath -> (a,[Namen]) -> Submission -> Rated m
 checkSemantics _ (_,nSol) (Table xs,f,n) = do
     let correctStart = take staticColumns columns == #{startingTable}
-    #{checkType} correctStart $ bothLangs
+    #{checkType} correctStart $ text
       "Spalten der atomaren Formeln ergeben sinnvolle Wahrheitstafel?"
     let subFormulas = all (\\e -> e `isSubFormula` f || e `elem` negations) $ catMaybes $ dropStatic replaceFAll
-    #{checkType} subFormulas $ bothLangs
+    #{checkType} subFormulas $ text
       "Als Tabellenspalten kommen nur Teilformeln der Gesamtformel vor?"
     let correctValues = all correctColumn zippedEntries && not (all (null . catMaybes . snd) zippedEntries)
-    #{checkType} correctValues $ bothLangs
+    #{checkType} correctValues $ text
       "Tafel ist gefüllt und Tabellenspalten enthalten nur korrekt ermittelte Wahrheitswerte?"
-    yesNo (T.all (`elem` f) "ABCD") $ bothLangs
+    yesNo (T.all (`elem` f) "ABCD") $ text
        "Gesamtformel enthält alle vorkommenden atomaren Formeln?"
     let correctFormula = isSemanticEqual (#{fSol}) (toSynTree f)
-    yesNo correctFormula $ bothLangs
-        "Gesamtformel ist korrekt?"
+    yesNo correctFormula $ text "Gesamtformel ist korrekt?"
     let correctNames = n == nSol
-    yesNo correctNames $ bothLangs
-       "Die Auflistung der Begleitenden ist korrekt?"
+    yesNo correctNames $ text "Die Auflistung der Begleitenden ist korrekt?"
     let correct = filter id [correctStart, correctFormula, correctNames, correctValues]
     let points = fromIntegral (length correct) % 4
     res <- printSolutionAndAssertMinimum (MinimumThreshold (1 % 4)) IndefiniteArticle maybeAnswer points
@@ -365,13 +356,13 @@ import Global
 
 description :: OutputCapable m => FilePath -> ((String,[String]),a) -> LangM m
 description _ ((legend,hints),_) = do
-    paragraph $ bothLangs
+    paragraph $ text
       ( "Eva möchte gerne auf ein Konzert ihrer Lieblingsband gehen. " ++
         legend ++
         "ob sie mitkommen wollen. Leider sind die Antworten etwas seltsam."
       )
-    itemizeM $ map bothLangs hints
-    paragraph $ bothLangs $
+    itemizeM $ map text hints
+    paragraph $ text $
       "Übersetzen Sie die Kombination der Antworten in eine aussagenlogische Formel. " ++
       "Geben Sie diese Formel in das entsprechend benannte Textfeld ein. " ++
       "Verwenden Sie dabei die atomaren Formeln A, B, C, D mit der Interpretation, " ++
@@ -379,10 +370,10 @@ description _ ((legend,hints),_) = do
     keyHeading
     basicOpKey True
     arrowsKey
-    paragraph $ bothLangs $
+    paragraph $ text $
       "Wer geht mit Eva zum Konzert? Leiten Sie Ihr Ergebnis mittels Wahrheitstafel her. " ++
       "Kreuzen Sie dann alle Begleitenden in der Namensliste an."
-    paragraph $ bothLangs $
+    paragraph $ text $
       "Beim Ausfüllen der Wahrheitstafel können Spalten leer gelassen werden. " ++
       "Sollten Sie für die Eingabe einer Formelüberschrift mehr Platz benötigen, " ++
       "können Sie die kleineren Eingabefelder überspringen und eines der größeren nutzen."

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -394,7 +394,6 @@ import FlexTask.Generic.Parse (
   escaped,
   parseWithFallback,
   withInput,
-  fully,
   parseWithOrReport,
   reportWithFieldNumber,
   )
@@ -403,6 +402,7 @@ import Formula.Parsing.Delayed (
   )
 import LogicTasks.Formula      (TruthValue)
 import LogicTasks.Parsing      (formulaSymbolParser, parser)
+import ParsingHelpers          (fully)
 import Trees.Types             (PropFormula(Atomic))
 
 import Global

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -410,11 +410,11 @@ import Global
 
 
 instance Parse TruthValue where
-  parseInput = escaped parser
+  formParser = escaped parser
 
 
 instance Parse [Namen] where
-  parseInput = parseInstanceMultiChoice
+  formParser = parseInstanceMultiChoice
 
 
 makeTable :: [Maybe (PropFormula Char)] -> [Maybe TruthValue] -> Table
@@ -426,7 +426,7 @@ makeTable headers values = Table $ zip allHeaders formattedTruthValues
 
 parseSubmission :: (Monad m, OutputCapable (ReportT o m)) => String -> LangM' (ReportT o m) Submission
 parseSubmission input =
-    parseWithOrReport parseInput reportWithFieldNumber input $>>= \(headerStrings,columns,formulaString,names) ->
+    parseWithOrReport formParser reportWithFieldNumber input $>>= \(headerStrings,columns,formulaString,names) ->
       traverse (traverse parseIt) headerStrings $>>= \parsedHeaders ->
         parseIt formulaString $>>= \parsedFormula ->
           pure (makeTable parsedHeaders columns, parsedFormula, names)

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -397,6 +397,7 @@ import FlexTask.Generic.Parse (
   parseInstanceMultiChoice,
   escaped,
   parseWithFallback,
+  withInput,
   fully,
   parseWithOrReport,
   reportWithFieldNumber,
@@ -437,5 +438,5 @@ parseSubmission input =
     parseIt =
       parseWithFallback
         (fully parser)
-        complainAboutMissingParenthesesIfNotFailingOn
+        (withInput complainAboutMissingParenthesesIfNotFailingOn)
         (fully formulaSymbolParser)

--- a/tasks/proplogic.txt
+++ b/tasks/proplogic.txt
@@ -391,9 +391,9 @@ import Data.List.Extra        (chunksOf, transpose)
 import FlexTask.Generic.Parse (
   Parse(..),
   parseInstanceMultiChoice,
+  displayInputAnd,
   escaped,
   parseWithFallback,
-  withInput,
   parseWithOrReport,
   reportWithFieldNumber,
   )
@@ -434,5 +434,5 @@ parseSubmission input =
     parseIt =
       parseWithFallback
         (fully parser)
-        (withInput complainAboutMissingParenthesesIfNotFailingOn)
+        (displayInputAnd complainAboutMissingParenthesesIfNotFailingOn)
         (fully formulaSymbolParser)


### PR DESCRIPTION
I felt that the special function `useParser` was not really warranted. Also, exposing `State (Map Language String) ()` to the user (for potentially writing their own error messaging functions) felt odd when `LangM' (ReportT o m) ())` could also be used.

There are a few issues to still consider:

The uses of `fully` throughout the diff are simply positioned so that the semantics is as before. But I find some of these uses dubious or at least not clearly motivated.

The function `bothLangs`, currently just defined in one of the specific task configs (but now also mentioned in the default config), should probably be provided by the `flex-tasks` library itself.

The positioning of `indent` calls (in error messaging functions) is not exactly as before. It's not clear to me where and when one wants to use `indent`, and whether that's not something better left to the user of the API to control, rather than doing it in the API functions themselves.

*[obsolete now:]* Maybe the `displayInput a` in `parseWithFallback` should be made optional, via a `Bool` argument to the function. I think the function might also be used in situations where there was only one big string in the input form overall, so no real point in printing out "one of many strings, in order to pinpoint the problematic one".

I think the `parseInput` should be renamed, maybe to `formParser`.