### PR TITLE
Parse error with field number fixes

### DIFF
--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -32,6 +32,7 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   toAbort,
   )
+import Data.List.Extra    (takeWhileEnd)
 import Data.Text          (Text)
 import GHC.Generics       (Generic(..), K1(..), M1(..), (:*:)(..))
 import Text.Parsec
@@ -335,12 +336,12 @@ Provide error report with positional information relative to an input form.
 reportWithFieldNumber :: OutputCapable m => String -> ParseError -> LangM m
 reportWithFieldNumber input e = do
     translate $ do
-      german $ "Fehler in Eingabefeld " ++ fieldNum ++ ":"
-      english $ "Error in input field " ++ fieldNum ++ ":"
+      german $ "Fehler in Eingabefeld" ++ errorInfo
+      english $ "Error in input field" ++ errorInfo
     indent $ text errors
     pure ()
   where
-    fieldNum = show $ length (filter (=='\a') consumed) `div` 2 + 1
+    fieldNum = show $ length (filter (`elem` ['\a','\b']) consumed) `div` 2 + 1
     errors = showErrorMessages
       "or"
       "unknown parse error"
@@ -349,6 +350,9 @@ reportWithFieldNumber input e = do
       "end of input"
       $ errorMessages e
     consumed = take (sourceColumn $ errorPos e) input
+    causedError = takeWhileEnd (/='\a') consumed
+    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ ":"
+
 
 displayInputAnd ::
   OutputCapable m =>

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -341,7 +341,7 @@ reportWithFieldNumber input e = do
     indent $ text errors
     pure ()
   where
-    fieldNum = show $ length (filter (`elem` ['\a','\b']) consumed) `div` 2 + 1
+    fieldNum = show $ length (filter isDelimiter consumed) `div` 2 + 1
     errors = showErrorMessages
       "or"
       "unknown parse error"
@@ -349,9 +349,11 @@ reportWithFieldNumber input e = do
       "unexpected"
       "end of input"
       $ errorMessages e
+    isDelimiter = flip elem ['\a','\b']
     consumed = take (sourceColumn $ errorPos e) input
-    causedError = takeWhileEnd (/='\a') consumed
-    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ ":"
+    restOfField = takeWhile (not . isDelimiter) $ drop (length consumed) input
+    causedError = takeWhileEnd (not . isDelimiter) consumed ++ restOfField
+    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ causedError ++ ":"
 
 
 displayInputAnd ::

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -353,7 +353,7 @@ reportWithFieldNumber input e = do
     consumed = take (sourceColumn $ errorPos e) input
     restOfField = takeWhile (not . isDelimiter) $ drop (length consumed) input
     causedError = takeWhileEnd (not . isDelimiter) consumed ++ restOfField
-    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ causedError ++ ":"
+    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ ":"
 
 
 displayInputAnd ::

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -32,7 +32,7 @@ import Control.OutputCapable.Blocks (
 import Control.OutputCapable.Blocks.Generic (
   toAbort,
   )
-import Data.List.Extra    (takeWhileEnd)
+import Data.List.Extra    (dropEnd, takeWhileEnd)
 import Data.Text          (Text)
 import GHC.Generics       (Generic(..), K1(..), M1(..), (:*:)(..))
 import Text.Parsec
@@ -350,11 +350,12 @@ reportWithFieldNumber input e = do
       "end of input"
       $ errorMessages e
     isDelimiter = flip elem ['\a','\b']
-    consumed = take (sourceColumn $ errorPos e) input
-    restOfField = takeWhile (not . isDelimiter) $ drop (length consumed) input
+    errorAt = sourceColumn $ errorPos e
+    consumed = take errorAt input
+    restOfField = takeWhile (not . isDelimiter) $ drop errorAt input
     fieldUntilError = takeWhileEnd (not . isDelimiter) consumed
-    causedError = filter (/='\"') $ fieldUntilError ++ restOfField
-    errorInfo = " " ++ fieldNum ++ ", " ++ "\"" ++ causedError ++ "\"" ++ ":"
+    causedError = drop 1 $ dropEnd 1 $ fieldUntilError ++ restOfField
+    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ ":"
 
 
 displayInputAnd ::

--- a/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
+++ b/flex-tasks/src/FlexTask/Generic/ParseInternal.hs
@@ -352,8 +352,9 @@ reportWithFieldNumber input e = do
     isDelimiter = flip elem ['\a','\b']
     consumed = take (sourceColumn $ errorPos e) input
     restOfField = takeWhile (not . isDelimiter) $ drop (length consumed) input
-    causedError = takeWhileEnd (not . isDelimiter) consumed ++ restOfField
-    errorInfo = " " ++ fieldNum ++ ", " ++ causedError ++ ":"
+    fieldUntilError = takeWhileEnd (not . isDelimiter) consumed
+    causedError = filter (/='\"') $ fieldUntilError ++ restOfField
+    errorInfo = " " ++ fieldNum ++ ", " ++ "\"" ++ causedError ++ "\"" ++ ":"
 
 
 displayInputAnd ::


### PR DESCRIPTION
- Give a more accurate number by not ignoring `\b` separators
- Display error causing input