### PR TITLE
Work on frontend JavaScript 

### DIFF
--- a/.github/actions/spelling/allow.txt
+++ b/.github/actions/spelling/allow.txt
@@ -18,6 +18,7 @@ github
 Graphviz
 Hspec
 html
+mempty
 mform
 MForms
 mopt

--- a/flex-tasks-processing/flex-tasks-processing.cabal
+++ b/flex-tasks-processing/flex-tasks-processing.cabal
@@ -11,6 +11,7 @@ build-type:     Simple
 library
   exposed-modules:
       FlexTask.Processing.Text
+      FlexTask.Processing.JavaScript
   other-modules:
       Paths_flex_tasks_processing
   hs-source-dirs:
@@ -28,6 +29,7 @@ library
   ghc-options: -Wall -Widentities -Werror
   build-depends:
       base
+    , shakespeare
     , text
   default-language: Haskell2010
 
@@ -56,5 +58,6 @@ test-suite flex-tasks-test
     , flex-tasks-processing
     , hspec
     , quickcheck-instances
+    , shakespeare
     , text
   default-language: Haskell2010

--- a/flex-tasks-processing/package.yaml
+++ b/flex-tasks-processing/package.yaml
@@ -4,6 +4,7 @@ extra-source-files: [ ]
 dependencies:
   - base
   - text
+  - shakespeare
 default-extensions:
   - TupleSections
   - DuplicateRecordFields
@@ -18,6 +19,7 @@ library:
   source-dirs: src
   exposed-modules:
     - FlexTask.Processing.Text
+    - FlexTask.Processing.JavaScript
   ghc-options:
     - -Wall
     - -Widentities

--- a/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
+++ b/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
@@ -1,0 +1,60 @@
+{-# language OverloadedStrings #-}
+{-# language QuasiQuotes #-}
+
+module FlexTask.Processing.JavaScript (
+  standaloneDefaultsJS,
+  setDefaultsJS,
+  ) where
+
+
+import Data.Text                        (Text)
+import Data.Text.Lazy                   (toStrict)
+import Text.Julius (
+  JavascriptUrl,
+  julius,
+  rawJS,
+  renderJavascriptUrl,
+  )
+
+
+
+standaloneDefaultsJS :: [Text] -> Text
+standaloneDefaultsJS ts =
+  "<script>" <>
+  toStrict (renderJavascriptUrl (\_ _ -> undefined) $ setDefaultsJS ts) <>
+  "</script>"
+
+
+setDefaultsJS :: [Text] -> JavascriptUrl url
+setDefaultsJS names = [julius|
+function setDefaults(values){
+  for(let i = 0; i < fieldNames.length; i++){
+    var input = values[i];
+    var fields = document.getElementsByName(fieldNames[i]);
+
+    for(let j = 0; j < fields.length; j++) {
+      var field = fields[j];
+      var fieldType = field.getAttribute("type");
+      var maybeDropdown = field.tagName;
+
+      if(fieldType != null && fieldType.toLowerCase() === "radio"){
+        field.checked = field.value == input;
+      }
+      else if(maybeDropdown != null && maybeDropdown.toLowerCase() === "select"){
+        for(const opt of Array.from(field.options)){
+          opt.selected = input.includes(opt.getAttribute("value"));
+        }
+      }
+      else if(fieldType != null && fieldType.toLowerCase() === "checkbox"){
+        field.checked = input.includes(field.getAttribute("value"));
+      }
+      else if(fieldType != null && fieldType.toLowerCase() !== "hidden"){
+        var inputElem = fields.length > 1 ? JSON.parse(input)[j] : input;
+        if(inputElem != "Missing" && inputElem != "None"){
+          field.value = inputElem;
+        }
+      }
+    }
+  }
+}
+var fieldNames = #{rawJS (show names)};|]

--- a/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
+++ b/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
@@ -1,13 +1,18 @@
+{-# language OverloadedStrings #-}
 {-# language QuasiQuotes #-}
 
 module FlexTask.Processing.JavaScript (
   setDefaultsJS,
+  triggerDefaults,
+  lockForm,
   ) where
 
 
 import Data.Text                        (Text)
 import Text.Julius                      (JavascriptUrl, julius, rawJS)
+import qualified Data.Text as T
 
+import FlexTask.Processing.Text         (formatForJS)
 
 
 setDefaultsJS :: [Text] -> JavascriptUrl url
@@ -43,3 +48,22 @@ function setDefaults(values){
   }
 }
 var fieldNames = #{rawJS (show names)};|]
+
+
+triggerDefaults :: Text -> JavascriptUrl url
+triggerDefaults t
+  | t == "[ ]" || T.length t < 2 = mempty
+  | otherwise = [julius|window.onload = setDefaults(#{rawJS (formatForJS t)});|]
+
+
+lockForm :: Bool -> JavascriptUrl url
+lockForm lock
+  | lock = [julius|window.onload =
+      function () {
+        for(const name of fieldNames) {
+          for(const elem of document.getElementsByName(name)){
+            elem.disabled = true;
+          }
+        }
+      };|]
+  | otherwise = mempty

--- a/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
+++ b/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
@@ -1,28 +1,13 @@
-{-# language OverloadedStrings #-}
 {-# language QuasiQuotes #-}
 
 module FlexTask.Processing.JavaScript (
-  standaloneDefaultsJS,
   setDefaultsJS,
   ) where
 
 
 import Data.Text                        (Text)
-import Data.Text.Lazy                   (toStrict)
-import Text.Julius (
-  JavascriptUrl,
-  julius,
-  rawJS,
-  renderJavascriptUrl,
-  )
+import Text.Julius                      (JavascriptUrl, julius, rawJS)
 
-
-
-standaloneDefaultsJS :: [Text] -> Text
-standaloneDefaultsJS ts =
-  "<script>" <>
-  toStrict (renderJavascriptUrl (\_ _ -> undefined) $ setDefaultsJS ts) <>
-  "</script>"
 
 
 setDefaultsJS :: [Text] -> JavascriptUrl url


### PR DESCRIPTION
- move scripts over from Autotool
- Make scripts available through `FlexTask.Processing`
- Add scripts in frontend instead of in the backend
- Remove obsolete `standaloneDefaultsJS`
- Refactor `setDefaultsJS` and `lockForm` scripts 