### PR TITLE
Remove need for exposed constructors in TaskData values

### DIFF
--- a/.github/actions/spelling/expect.txt
+++ b/.github/actions/spelling/expect.txt
@@ -5,6 +5,7 @@ getline
 gformify
 ghs
 gparse
+gread
 gshow
 gsub
 hlint

--- a/flex-tasks/src/FlexTask/Interpreter.hs
+++ b/flex-tasks/src/FlexTask/Interpreter.hs
@@ -172,9 +172,11 @@ makeDescription taskData global settings description extras picPath = do
         , "Capabilities.LatexSvg.IO"
         , "Capabilities.WriteFile.IO"
         , "Control.OutputCapable.Blocks.Generic.Type"
+        , "Data.Generics.Text"
+        , "Data.List.Extra"
         , "Data.Text"
         ]
-      interpret ("description " ++ show picPath ++ parens taskData) infer
+      interpret ("description " ++ show picPath ++ parens (greadError taskData)) infer
 
 
 
@@ -275,13 +277,15 @@ checkSolution taskData globalCode settingsCode parseCode checkCode extraCode sub
         , "Capabilities.WriteFile.IO"
         , "Control.OutputCapable.Blocks.Generic.Type"
         , "Control.OutputCapable.Blocks"
+        , "Data.Generics.Text"
+        , "Data.List.Extra"
         , "Data.Ratio"
         , "Data.Text"
         ]
       setTopLevelModules ["Check", "Global", "Helper", "Parse"]
       interpret ("syntaxAndSemantics parseSubmission checkSyntax checkSemantics " ++ input ++ path ++ tData) infer
 
-    tData = parens taskData
+    tData = parens $ greadError taskData
     input = removeUnicodeEscape (show $ replace "\\\\" "\\" submission)
     path = show picPath
 
@@ -355,3 +359,9 @@ prettyError (UnknownError s) = "Unknown error:\n" ++ s
 prettyError (NotAllowed s) = "Not allowed:\n" ++ s
 prettyError (GhcException s) = "GHC exception occurred:\n" ++ s
 prettyError (WontCompile ghcErrors) = "Won't compile:\n" ++ unlines (map errMsg ghcErrors)
+
+
+greadError :: String -> String
+greadError term = "fst $ headDef (error " ++ show errorMessage ++") $ gread " ++ show term
+  where
+    errorMessage = "Failed reading stored TaskData. Encountered this: " ++ term

--- a/stack-test.yaml
+++ b/stack-test.yaml
@@ -16,8 +16,6 @@ extra-deps:
   - call-alloy-0.6.0.2@sha256:f7ecb0f4b8f7cc804d6d8ace7c323b48e3aa03994a2d09c4b7ee66cc4bf15abd,3850
   - diagrams-graphviz-1.4.1.1@sha256:9a2bf7b7c9c86ab28228d36017c70cf1b53c95dae4004fc71e81fbc702098e9f,1495
   - latex-svg-image-0.2@sha256:b282a74a96724037ec3d24b664118e51170c8152aff12f363ddb715a38ef053a,1830
-  # my fork of syb fixing a bug in 'gread'
-  - git: https://github.com/patritzenfeld/syb.git
-    commit: 8568a11e0fc70c2a6055c65f3791ef075fd9c0f5
+  - syb-0.7.3
 
 allow-newer: true

--- a/stack-test.yaml
+++ b/stack-test.yaml
@@ -16,5 +16,8 @@ extra-deps:
   - call-alloy-0.6.0.2@sha256:f7ecb0f4b8f7cc804d6d8ace7c323b48e3aa03994a2d09c4b7ee66cc4bf15abd,3850
   - diagrams-graphviz-1.4.1.1@sha256:9a2bf7b7c9c86ab28228d36017c70cf1b53c95dae4004fc71e81fbc702098e9f,1495
   - latex-svg-image-0.2@sha256:b282a74a96724037ec3d24b664118e51170c8152aff12f363ddb715a38ef053a,1830
+  # my fork of syb fixing a bug in 'gread'
+  - git: https://github.com/patritzenfeld/syb.git
+    commit: 8568a11e0fc70c2a6055c65f3791ef075fd9c0f5
 
 allow-newer: true


### PR DESCRIPTION
Fixed a bug in `gread` to allow use of that function. TaskData is now parsed by `gread` instead of being written into the file as code.