### PR TITLE
add unsafe version of `getFormData`

### DIFF
--- a/flex-tasks/src/FlexTask/ConvertForm.hs
+++ b/flex-tasks/src/FlexTask/ConvertForm.hs
@@ -3,6 +3,7 @@
 
 module FlexTask.ConvertForm (
   getFormData,
+  unsafeGetFormData,
   ) where
 
 
@@ -12,6 +13,7 @@ import Control.Monad.Reader             (runReader)
 import Data.Map                         (fromList)
 import Data.IORef                       (readIORef, writeIORef)
 import Data.Text                        (Text)
+import System.IO.Unsafe                 (unsafePerformIO)
 import System.Log.FastLogger            (defaultBufSize, newStdoutLoggerSet)
 import Text.Blaze.Html.Renderer.String  (renderHtml)
 import Yesod
@@ -61,6 +63,22 @@ getFormData widget = do
         ^{pageBody content}|]
       return (names, (lang, concat $ lines $ renderHtml html))
 
+
+{- |
+Extract a form from the environment.
+The result is a tuple of field IDs and a map of language and internationalized html pairs.
+
+__This function employs `unsafePerformIO`!__
+It should never be used if `getFormData` is applicable instead.
+
+Intended to be used on non-randomized Autotool tasks (called "direct") where an IO context is not available.
+
+Generally, usage of this should be safe if the `Rendered Widget` argument does not incorporate `liftIO` calls.
+This will always be the case for non-custom forms.
+For custom forms, the user is responsible for making sure such calls are avoided or considered "safe".
+-}
+unsafeGetFormData :: Rendered Widget -> ([[Text]], HtmlDict)
+unsafeGetFormData = unsafePerformIO . getFormData
 
 
 -- Manipulate the request data to use a specific language.


### PR DESCRIPTION
For use in `direct` tasks in Autotool.

As discussed, this library should provide such unsafe functions instead of using `unsafePerformIO` in Autotool itself. As of now, I could not find any way of avoiding the IO context in form generation (mostly because of the required [HandlerFor](https://hackage.haskell.org/package/yesod-core-1.6.26.0/docs/Yesod-Core-Types.html#t:HandlerFor) type) without essentially copying and altering half of the Yesod code.

I want to have a really deep look into the Yesod code base eventually. There might still be something I missed or do not understand properly that could help avoid usage of `unsafePerformIO` in this situation. 