### PR TITLE
Bandaid fix for javascript issue

### DIFF
--- a/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
+++ b/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
@@ -68,7 +68,7 @@ setDefaultsJS names = [julius|
       else {
         const name = names[0];
         const fields = Array.from(document.getElementsByName(name));
-        const isList = Array.isArray(raw) || /^[\[\{]/.test(raw);
+        const isList = Array.isArray(raw) || /^\[\"/.test(raw);
 
         fields.forEach((field, j) => {
           let val;


### PR DESCRIPTION
Addresses #159. Tasks using `{` in String literals will no longer break. There is however still an issue using certain combinations of `[` together with `"`. This can hopefully be fixed incidentally by working on #160.