### PR TITLE
fix form locking

### DIFF
--- a/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
+++ b/flex-tasks-processing/src/FlexTask/Processing/JavaScript.hs
@@ -103,7 +103,7 @@ lockForm :: Bool -> JavascriptUrl url
 lockForm lock
   | lock = [julius|window.onload =
     function () {
-      fieldNames.forEach(name => {
+      fieldNames.flat().forEach(name => {
         Array.from(document.getElementsByName(name))
           .forEach(elem => {
             if (elem.getAttribute("type")?.toLowerCase() === "radio" ||


### PR DESCRIPTION
Did not flatten the nested list of field names. This still worked for single inputs, since an Array of size 1 gets coerced into a correctly formatted String, but failed for list inputs.