### PR TITLE
Improve form duplication for Autotool comments

### DIFF
--- a/flex-tasks-processing/src/FlexTask/Processing/Text.hs
+++ b/flex-tasks-processing/src/FlexTask/Processing/Text.hs
@@ -145,7 +145,9 @@ uniqueFormCopy (params,html) uniqueId = (newParams, alteredHtml)
     suffix = '-' : uniqueId
     newParams = map (map (<> T.pack suffix)) params
     alteredHtml = preEscapedToHtml $ foldr
-      ( (\param -> replace ("name=\"" <> param <> "\"") ("name=\"" <> param <> suffix <> "\"")) .
+      ( (\param -> replace ("'" <> param <> "'") ("'" <> param <> suffix <> "'") .
+            replace ("\"" <> param <> "\"") ("\"" <> param <> suffix <> "\"")
+        ) .
         T.unpack
       )
       (renderHtml html)


### PR DESCRIPTION
Replace quoted names everywhere, not just in the name attribute. This prevented JavaScript from working correctly in comment views.