### PR TITLE
Prevent outdated Autotool configs becoming inaccessible

### DIFF
--- a/flex-tasks/src/FlexTask/Interpreter.hs
+++ b/flex-tasks/src/FlexTask/Interpreter.hs
@@ -74,12 +74,22 @@ validateSettings
   :: String   -- ^ The task identifier used for caching
   -> String   -- ^ Global module
   -> String   -- ^ Module containing configuration options
+  -> String   -- ^ TaskData module
+  -> String   -- ^ Description module
   -> [(String,String)] -- ^ Additional code modules
   -> IO (Either InterpreterError (Bool,[Output]))
-validateSettings taskName globalCode settingsCode extraCode = do
+validateSettings
+  taskName
+  globalCode
+  settingsCode
+  taskDataCode
+  descriptionCode
+  extraCode = do
     filePaths <- writeUncachedAndGetPaths taskName $
       [ ("Global", globalCode)
       , ("TaskSettings", settingsCode)
+      , ("TaskData", taskDataCode)
+      , ("Description", descriptionCode)
       ] ++ extraCode
     runWithPackageDB (loadModules filePaths >> validate)
   where


### PR DESCRIPTION
closes #237

This will declare the config as invalid instead of proceeding and throwing an error if `Description` or `TaskData` do not compile.

This actually did not reduce performance much (by my perception) , even though two extra modules are loaded. Maybe the cost of loading additional code in the background like that isn't as high as I thought.